### PR TITLE
Changed TCnMethodHook to use DDetours. See issue https://github.com/cnpack/cnwizards/issues/2

### DIFF
--- a/Source/DDetours/DDetours.pas
+++ b/Source/DDetours/DDetours.pas
@@ -1,0 +1,1061 @@
+// **************************************************************************************************
+// Delphi Detours Library
+// Unit DDetours
+// http://code.google.com/p/delphi-detours-library/
+
+// The contents of this file are subject to the Mozilla Public License Version 1.1 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.mozilla.org/MPL/
+//
+// Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
+// ANY KIND, either express or implied. See the License for the specific language governing rights
+// and limitations under the License.
+//
+// The Original Code is DDetours.pas.
+//
+// Contributor(s): David Millington
+//
+// The Initial Developer of the Original Code is Mahdi Safsafi [SMP3].
+// Portions created by Mahdi Safsafi . are Copyright (C) 2013-2014 Mahdi Safsafi .
+// All Rights Reserved.
+//
+// **************************************************************************************************
+{
+  RECENT CHANGES:
+
+  ==>  July 25,2014 , Mahdi Safsafi :
+  - Added GenericsCast unit to performe casting between generics types .
+
+  ==>  July 24,2014 , Mahdi Safsafi :
+  - Added _PointerToT,_TToPointer functions to fix bug in delphi
+  versions that have bug when using 'absolute' in a generic method .
+  - Added CheckTType function to check if T is procedure .
+}
+
+unit DDetours;
+
+interface
+
+{$I dDefs.inc}
+
+uses
+  Windows,
+  InstDecode
+{$IFDEF MustUseGenerics}
+    ,
+  SysUtils,
+  Typinfo,
+  GenericsCast
+{$ENDIF MustUseGenerics}
+    ;
+
+{$IFNDEF BuildThreadSafe}
+{$MESSAGE WARN 'BuildThreadSafe not defined , the library is not a thread safe .'}
+{$MESSAGE HINT 'Define BuildThreadSafe to make the library thread safe .'}
+{$ENDIF}
+{$IFNDEF DEBUG}
+{$WARN COMPARISON_TRUE OFF}
+{$ENDIF}
+// ---------------------------------------------------------------------------------
+function InterceptCreate(const TargetProc, InterceptProc: Pointer)
+  : Pointer; stdcall;
+function InterceptRemove(var Trampoline: Pointer): Boolean; stdcall;
+function MakeProcObj(var Proc; const Obj: Pointer): Boolean; stdcall;
+
+{$IFDEF MustUseGenerics}
+
+type
+  DetourException = class(Exception);
+
+const
+  SInvalidTType = '%s must be procedure.';
+
+type
+  TDetour<T> = class
+    function CheckTType: Boolean;
+  private
+    FTargetProc: Pointer;
+    FInterceptProc: Pointer;
+    FTrampoline: T;
+    function GetInstalled: Boolean;
+    function PointerToT(const P: Pointer): T;
+    function TToPointer(const AT: T): Pointer;
+    function GetTrampoline: T;
+  public
+    constructor Create(const TargetProc, InterceptProc: T);
+    destructor Destroy; override;
+    procedure Enable;
+    procedure Disable;
+    property Trampoline: T read GetTrampoline; // Call the original
+    property Installed: Boolean read GetInstalled;
+  end;
+{$ENDIF MustUseGenerics}
+
+implementation
+
+{$IFDEF BuildThreadSafe}
+{$IFNDEF FPC}
+
+// Delphi
+uses
+  TLHelp32;
+{$ELSE FPC}
+
+type
+  tagTHREADENTRY32 = record
+    dwSize: DWORD;
+    cntUsage: DWORD;
+    th32ThreadID: DWORD; // this thread
+    th32OwnerProcessID: DWORD; // Process this thread is associated with
+    tpBasePri: Longint;
+    tpDeltaPri: Longint;
+    dwFlags: DWORD;
+  end;
+
+  THREADENTRY32 = tagTHREADENTRY32;
+  PTHREADENTRY32 = ^tagTHREADENTRY32;
+  LPTHREADENTRY32 = ^tagTHREADENTRY32;
+  TThreadEntry32 = tagTHREADENTRY32;
+
+  TCreateToolhelp32Snapshot = function(dwFlags, th32ProcessID: DWORD)
+    : THandle stdcall;
+  TThread32First = function(hSnapshot: THandle; var lpte: TThreadEntry32)
+    : BOOL stdcall;
+  TThread32Next = function(hSnapshot: THandle; var lpte: TThreadEntry32)
+    : BOOL stdcall;
+
+var
+  CreateToolhelp32Snapshot: TCreateToolhelp32Snapshot;
+  Thread32First: TThread32First;
+  Thread32Next: TThread32Next;
+
+const
+  TH32CS_SNAPTHREAD = $00000004;
+{$ENDIF FPC}
+
+type
+  TThreadsListID = class
+  private
+    FCount: UINT;
+    FPointer: Pointer;
+    FSize: UINT;
+  public
+    procedure Add(const Value: DWORD);
+    function GetID(const Index: UINT): DWORD;
+    constructor Create; virtual;
+    destructor Destroy; override;
+    property Count: UINT read FCount;
+    property ThreadIDs[const index: UINT]: DWORD read GetID;
+  end;
+
+type
+  TOpenThread = function(dwDesiredAccess: DWORD; bInheritHandle: BOOL;
+    dwThreadId: DWORD): THandle; stdcall;
+
+var
+  OpenThread: TOpenThread;
+  hKernel: THandle;
+  OpenThreadExist: Boolean = False;
+  FreeKernel: Boolean = False;
+{$ENDIF BuildThreadSafe}
+
+type
+{$IFDEF CPUX86}
+  PRelativeJump = ^TRelativeJump;
+
+  TRelativeJump = Packed Record
+    OpCode: Byte;
+    Offset: Integer;
+  end;
+{$ELSE !CPUX86}
+
+  PIndirectJump = ^TIndirectJump;
+
+  TIndirectJump = Packed Record
+    OpCode: Word;
+    Offset: Integer;
+  end;
+{$ENDIF !CPUX86}
+{$IFDEF CPUX86}
+
+  TJumpInst = TRelativeJump;
+{$ELSE !CPUX86}
+  TJumpInst = TIndirectJump;
+{$ENDIF !CPUX86}
+  PJumpInst = ^TJumpInst;
+
+  PSaveData = ^TSaveData;
+
+  TSaveData = packed record
+    D1: Pointer; // Target Proc Address .
+    D2: Pointer; // InterceptProc Proc Address .
+    Sb: Byte; // Stolen Bytes .
+    Size32: Boolean;
+  end;
+
+const
+  SizeOfJmp = SizeOf(TJumpInst);
+  opNop = $90;
+  opJmpIndirect = $25FF; // jmp dword ptr[<Address>]
+  opJmpRelative = $E9; // jmp <Displacement>
+  opInt3 = $CC; // int 3 (debug breakpoint)
+{$IFDEF CPUX86}
+  CPUX: TCPUX = CPUX32;
+  opJmp = opJmpRelative;
+{$ELSE !CPUX86}
+  CPUX: TCPUX = CPUX64;
+  opJmp = opJmpIndirect;
+{$ENDIF !CPUX86}
+  TrampolineSize = (SizeOf(Pointer) shl 3) + SizeOf(TSaveData);
+
+{$IFDEF DEBUG}
+{$DEFINE SkipInt3}
+{$ENDIF}
+
+function HiQword(const Value: UINT64): DWORD; overload;
+{$IFDEF MustInline}inline; {$ENDIF}
+begin
+  Result := (Value shr 32);
+end;
+
+function HiQword(const Value: Int64): DWORD; overload;
+{$IFDEF MustInline}inline; {$ENDIF}
+begin
+  Result := (Value shr 32);
+end;
+
+procedure FillNop(const Address: Pointer; const Count: Integer);
+{$IFDEF MustInline}inline; {$ENDIF}
+begin
+  FillChar(Address^, Count, opNop);
+end;
+
+function IsOpUnCondJmpWithNoReg(const Addr: PByte): Boolean;
+var
+  Inst: TInstruction;
+begin
+  {
+    Return true if instruction is Unconditional Jump and does not use Registers  .
+    e.g : JMP DWORD PTR DS:[Address] . => Result = True .
+  }
+  Result := False;
+  FillChar(Inst, SizeOf(TInstruction), #0);
+  DecodeInstruction(Addr, @Inst, CPUX);
+  if Inst.ModRM.Used then
+  begin
+    if Inst.ModRM.rMod <> 0 then
+      if Inst.ModRM.rRM <> 5 then
+        Exit;
+    {
+      e.g :
+      JMP EAX  .
+      JMP DWORD PTR DS:[EAX+10] .
+      => Result = False .
+    }
+  end;
+  if Inst.nOpCode = 1 then
+  begin
+    Result := Inst.OpCode in [$E9, $EB];
+    if not Result then
+      if Inst.OpCode = $FF then
+        Result := (Inst.ModRM.rReg in [4, 5]);
+    // rReg = extension for opCode !
+  end
+  else if Inst.nOpCode = 2 then
+  begin
+    Result := (HiByte(Inst.OpCode) = 0) and (Inst.ModRM.rReg = 6);
+    // rReg = extension for opCode ! => JMPE .
+  end
+  else
+    Result := False;
+end;
+
+{$HINTS OFF}
+
+function IsOpRel(const Addr: Pointer): Boolean;
+var
+  P: PByte;
+  Op: Word;
+  Inst: TInstruction;
+begin
+  { Check if instruction use relative offset .
+    eg : JE -5 .
+  }
+  Result := False;
+  P := PByte(Addr);
+  Op := PWORD(P)^;
+  FillChar(Inst, SizeOf(TInstruction), #0);
+  DecodeInstruction(P, @Inst, CPUX);
+  Result := (Inst.Displacement.Used) and (Inst.Displacement.Relative);
+  if Result then
+    Exit;
+  if Byte(Op) = $F then
+  begin
+    Result := HiByte(Op) in [$80 .. $8F]; // Jump.
+  end
+  else if Byte(Op) <> $F then
+  begin
+    Result := P^ in [$70 .. $7F, $E0 .. $E3, $E8, $E9, $EB];
+  end
+  else
+    Result := False;
+end;
+{$HINTS ON}
+
+function GetRoot(const P: Pointer; Inst: TInstruction): Pointer;
+var
+  Q: PByte;
+begin
+  Result := P;
+  FillChar(Inst, SizeOf(TInstruction), Char(0));
+  DecodeInstruction(P, @Inst, CPUX);
+  if (Inst.JumpCall.JumpUsed) and IsOpUnCondJmpWithNoReg(P) then
+  begin
+    Q := Pointer(Inst.JumpCall.Address);
+    Result := GetRoot(Q, Inst);
+  end;
+end;
+
+function SetMemPermission(const Code: Pointer; const Size: Integer;
+  const Permission: DWORD): DWORD;
+begin
+  Result := 0;
+  if Assigned(Code) and (Size > 0) and (Permission > 0) then
+    if FlushInstructionCache(GetCurrentProcess, Code, Size) then
+      VirtualProtect(Code, Size, Permission, Result);
+end;
+
+procedure CorrectRelOffset(const Src, Dst: Pointer; const Inst: TInstruction);
+var
+  NewOffset: Integer;
+  Addr: Int64;
+  Q: PByte;
+  OffsetAddr: Pointer;
+begin
+  Q := PByte(Dst);
+  if (CPUX = CPUX64) and (Inst.JumpCall.Used) and
+    (Inst.JumpCall.IndirectDispOnly) then
+  begin
+    { e.g: jmp qword ptr [rel $0000ad9c] }
+    // Addr := Inst.JumpCall.Address;
+    { OffsetAddr = EIP + Offset }
+    OffsetAddr := Pointer(UINT64(Src) + Inst.JumpCall.Offset + Inst.InstSize);
+    { Offset = OffsetAddr - EIP }
+    NewOffset := Integer(UINT64(OffsetAddr) - UINT64(Q) - Inst.InstSize);
+    { Set the new Offset . }
+    Inc(Q, Inst.InstSize - Inst.JumpCall.OffsetSize);
+    PInteger(Q)^ := NewOffset;
+  end
+  else if (CPUX = CPUX64) and (Inst.Displacement.Used) and
+    (Inst.Displacement.Relative) then
+  begin
+    {
+      mov rax,[rel $00000011]
+      We can not copy this instruction directly .
+      We need to correct the offset $00000011 .
+    }
+    OffsetAddr := Pointer(UINT64(Src) + Inst.Displacement.Value +
+      Inst.InstSize);
+    NewOffset := UINT64(OffsetAddr) - UINT64(Q) - Inst.InstSize;
+    if Inst.Displacement.i32 then
+    begin
+      { Four Bytes Displacement }
+      Inc(Q, Inst.InstSize - 4);
+      PInteger(Q)^ := NewOffset;
+    end
+    else
+    begin
+      { One Byte Displacement }
+      Inc(Q, Inst.InstSize - 1);
+      PByte(Q)^ := Byte(NewOffset);
+    end;
+  end
+  else if (Inst.JumpCall.Relative) and (Inst.JumpCall.Used) then
+  begin
+    { JMP Relative }
+    Addr := Inst.JumpCall.Address;
+    NewOffset := UINT64(Addr) - UINT64(Dst) - Inst.InstSize;
+    Inc(Q, Inst.InstSize - Inst.JumpCall.OffsetSize);
+    case Inst.JumpCall.OffsetSize of
+      1:
+        PShortInt(Q)^ := ShortInt(NewOffset);
+      2:
+        PShort(Q)^ := Short(NewOffset);
+      4:
+        PInteger(Q)^ := NewOffset;
+    end;
+  end;
+end;
+
+procedure CopyInstruction(const Src; var Dst; const Size: ShortInt);
+var
+  PSrc, PDst: PByte;
+  S: ShortInt;
+  Inst: TInstruction;
+  i: Integer;
+begin
+  i := 0;
+  PSrc := PByte(@Src);
+  PDst := PByte(@Dst);
+  while i < Size do
+  begin
+    FillChar(Inst, SizeOf(TInstruction), #0);
+    S := DecodeInstruction(PSrc, @Inst, CPUX);
+{$IFDEF SkipInt3}
+    if PSrc^ <> opInt3 then
+{$ENDIF SkipInt3}
+    begin
+      Move(PSrc^, PDst^, S);
+      if IsOpRel(PSrc) then
+        CorrectRelOffset(PSrc, PDst, Inst);
+      Inc(PDst, S);
+    end;
+    Inc(PSrc, S);
+    Inc(i, S);
+  end;
+end;
+
+function AddrAllocMem(const Addr: Pointer;
+  const Size, flProtect: DWORD): Pointer;
+var
+  mbi: TMemoryBasicInformation;
+  Info: TSystemInfo;
+  P, Q: UINT64;
+  PP: Pointer;
+begin
+  { Alloc memory on the specific nearest address from the Addr . }
+  Result := nil;
+  if Addr = nil then
+  begin
+    Result := VirtualAlloc(nil, Size, MEM_COMMIT, flProtect);
+    Exit;
+  end;
+  P := UINT64(Addr);
+  Q := UINT64(Addr);
+  GetSystemInfo(Info);
+  { Interval = [2GB ..P.. 2GB] = 4GB }
+  if Int64(P - (High(DWORD) div 2)) < 0 then
+    P := 1
+  else
+    P := UINT64(P - (High(DWORD) div 2)); // -2GB .
+  if UINT64(Q + (High(DWORD) div 2)) > High( {$IFDEF CPUX64}UINT64
+{$ELSE}UINT
+{$ENDIF} ) then
+    Q := High( {$IFDEF CPUX64}UINT64 {$ELSE}UINT {$ENDIF} )
+  else
+    Q := Q + (High(DWORD) div 2); // + 2GB .
+
+  while P < Q do
+  begin
+    PP := Pointer(P);
+    if VirtualQuery(PP, mbi, Size) = 0 then
+      Break;
+    if (mbi.State and MEM_FREE = MEM_FREE) and (mbi.RegionSize > Size) then
+      { Yes there is a memory that we can use ! }
+      if (mbi.RegionSize >= Info.dwAllocationGranularity) then
+      begin
+        { The RegionSize must be greater than the dwAllocationGranularity . }
+        { The address (PP) must be multiple of the allocation granularity (dwAllocationGranularity) . }
+        PP := Pointer(Info.dwAllocationGranularity *
+          (UINT64(PP) div Info.dwAllocationGranularity) +
+          Info.dwAllocationGranularity);
+        {
+          If PP is multiple of dwAllocationGranularity then alloc memory .
+          If PP is not multiple of dwAllocationGranularity ,the VirtualAlloc will fails .
+        }
+        if UINT64(PP) mod Info.dwAllocationGranularity = 0 then
+          Result := VirtualAlloc(PP, Size, MEM_COMMIT or MEM_RESERVE,
+            flProtect);
+        if Result <> nil then
+          Exit;
+      end;
+    P := UINT64(mbi.BaseAddress) + mbi.RegionSize; // Next region .
+  end;
+end;
+
+{$IFOPT Q+}
+{$DEFINE Q_On}
+{$ENDIF}
+{$Q-}
+
+function DoInterceptCreate(const TargetProc, InterceptProc: Pointer): Pointer;
+var
+  P, Q: PByte;
+  PJmp: PJumpInst;
+  Sb, nb: Byte;
+  OrgProcAccess: DWORD;
+  Inst: TInstruction;
+  PSave: PSaveData;
+{$IFDEF CPUX64}
+  Offset: Int64;
+  J: UINT64;
+{$ELSE !CPUX64}
+  Offset: Integer;
+{$ENDIF !CPUX64}
+  Size32: Boolean;
+begin
+  P := PByte(TargetProc);
+  { Alloc memory for the trampoline routine . }
+{$IFDEF CPUX64}
+  Result := AddrAllocMem(TargetProc, TrampolineSize, PAGE_EXECUTE_READWRITE);
+{$ELSE !CPUX64}
+  Result := VirtualAlloc(nil, TrampolineSize, MEM_COMMIT,
+    PAGE_EXECUTE_READWRITE);
+{$ENDIF !CPUX64}
+  Q := Result;
+  if not Assigned(Result) then
+    Exit; // Failed !
+
+  Sb := 0;
+  Size32 := True;
+  Inc(Q, SizeOf(TSaveData));
+  // Reserved for the extra bytes that hold information about address .
+
+  { Offset between the trampoline and the target proc address . }
+{$IFDEF CPUX64}
+  PSave := PSaveData(Q);
+  Offset := Int64(UINT64(PSave) - UINT64(P) - SizeOfJmp);
+  // Sign Extended ! .
+  // {$ELSE}
+  // Offset := Integer(UINT(PSave) - UINT(P) - SizeOfJmp); // Sign Extended ! .
+{$ENDIF CPUX64}
+  nb := SizeOfJmp; // Numbers of bytes needed .
+
+{$IFDEF CPUX64}
+  if Offset < 0 then
+    J := UINT64(-Offset)
+  else
+    J := UINT64(Offset);
+
+  if HiQword(J) <> 0 then
+  begin
+    { The size of offset is too big than the size of dword . }
+    Size32 := False;
+    Inc(nb, SizeOf(Pointer));
+  end;
+{$ENDIF CPUX64}
+  { Calculate the Stolens instructions . }
+  while Sb < nb do
+  begin
+    { Get information about the instruction . }
+    FillChar(Inst, SizeOf(TInstruction), Char(0));
+    DecodeInstruction(P, @Inst, CPUX);
+{$IFDEF SkipInt3}
+    if Inst.OpCode <> opInt3 then
+{$ENDIF SkipInt3}
+      Inc(Sb, Inst.InstSize);
+    Inc(P, Inst.InstSize); // Next Instruction .
+  end;
+  P := PByte(TargetProc); // Restore the old value .
+
+  { The size is not enough to insert the Jump instruction }
+  if Sb < nb then
+    Exit
+
+    { Don't copy beyond the trampoline }
+  else if Sb > (TrampolineSize - SizeOf(TSaveData) - SizeOfJmp) then
+    Exit;
+
+  { Allow writing to the target proc ==> So we can insert the jump instruction . }
+  OrgProcAccess := SetMemPermission(P, nb, PAGE_EXECUTE_READWRITE);
+  { Copy the stolens instructions from the target proc to the trampoline proc . }
+  CopyInstruction(P^, Q^, Sb);
+
+  if Sb > nb then
+    FillNop(Pointer(NativeUInt(P) + nb), Sb - nb);
+  // Fill the rest bytes with NOP instruction .
+
+  if not Size32 then
+  begin
+    { The variable that hold the destination will be inserted
+      on the target proc (after the jump instruction)
+      => We are going to use JMP instuction with RIP without offset .
+      => JMP [RIP] .
+    }
+    PSave := PSaveData(P);
+    Inc(PByte(PSave), SizeOfJmp);
+  end
+  else
+    { The variable that hold the destination will be inserted
+      on the trampoline proc (before the stolens instructions)
+    }
+    PSave := PSaveData(Result);
+
+  PSave^.D1 := InterceptProc;
+
+  { Calculate the offset between the InterceptProc variable and the jmp instruction (target proc) . }
+{$IFDEF CPUX64}
+  Offset := Int64(UINT64(PSave) - UINT64(P) - SizeOfJmp);
+  // Sign Extended ! .
+{$ELSE !CPUX64}
+  Offset := Integer(UINT(InterceptProc) - UINT(P) - SizeOfJmp);
+  // Sign Extended ! .
+{$ENDIF !CPUX64}
+  { Insert JMP instruction . }
+  PJmp := PJumpInst(P);
+  PJmp^.OpCode := opJmp;
+  PJmp^.Offset := Integer(Offset);
+
+  { Save the InterceptProc and the TargetProc address on the trampoline routine . }
+  PSave := PSaveData(Result);
+  PSave^.D1 := InterceptProc;
+  PSave^.D2 := Pointer(UINT64(P) + nb);
+  PSave^.Sb := Sb;
+  PSave^.Size32 := Size32;
+
+  Q := Result;
+  Inc(Q, Sb + SizeOf(TSaveData)); // Address of JMP instruction .
+
+  { Calculate the offset between the TargetProc variable and the jmp instruction (Trampoline proc) . }
+{$IFDEF CPUX64}
+  Offset := Int64((UINT64(PSave) + SizeOf(Pointer)) - UINT64(Q) - SizeOfJmp);
+  // Sign Extended ! .
+{$ELSE !CPUX64}
+  Offset := Integer((UINT(PSave^.D2) - UINT(Q) - SizeOfJmp));
+  // Sign Extended ! .
+{$ENDIF !CPUX64}
+  { Insert JMP instruction . }
+  PJmp := PJumpInst(Q);
+  PJmp^.OpCode := opJmp;
+  PJmp^.Offset := Integer(Offset);
+
+  { Skip the Saved data on the Trampoline .
+    => So it will never be executed .
+  }
+  Inc(PByte(Result), SizeOf(TSaveData));
+
+  { Restore TargetProc old permission . }
+  SetMemPermission(P, Sb, OrgProcAccess);
+end;
+{$IFDEF Q_On}
+{$Q+ }
+{$ENDIF Q_On}
+// ------------------------------------------------------------------------------
+{$IFDEF BuildThreadSafe }
+
+const
+  THREAD_SUSPEND_RESUME = $0002;
+
+function SuspendAllThreads(RTID: TThreadsListID): Boolean;
+var
+  hSnap: THandle;
+  PID: DWORD;
+  te: TThreadEntry32;
+  nCount: DWORD;
+  hThread: THandle;
+begin
+  PID := GetCurrentProcessId;
+
+  hSnap := CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, PID);
+
+  Result := hSnap <> INVALID_HANDLE_VALUE;
+
+  if Result then
+  begin
+    te.dwSize := SizeOf(TThreadEntry32);
+    if Thread32First(hSnap, te) then
+    begin
+      while True do
+      begin
+        if te.th32OwnerProcessID = PID then
+          { Allow the caller thread to access the Detours .
+            => Suspend all threads ,except the current thread .
+          }
+          if te.th32ThreadID <> GetCurrentThreadId then
+          begin
+            hThread := OpenThread(THREAD_SUSPEND_RESUME, False,
+              te.th32ThreadID);
+            if hThread <> INVALID_HANDLE_VALUE then
+            begin
+              nCount := SuspendThread(hThread);
+              if nCount <> DWORD(-1) then // thread's previously was running  .
+                RTID.Add(te.th32ThreadID);
+              // Only add threads that was running before suspending them !
+              CloseHandle(hThread);
+            end;
+          end;
+        if not Thread32Next(hSnap, te) then
+          Break;
+      end;
+    end;
+    CloseHandle(hSnap);
+  end;
+end;
+
+function ResumeSuspendedThreads(RTID: TThreadsListID): Boolean;
+var
+  i: Integer;
+  TID: DWORD;
+  hThread: THandle;
+begin
+  Result := False;
+  if Assigned(RTID) then
+    for i := 0 to RTID.Count do
+    begin
+      TID := RTID.ThreadIDs[i];
+      if TID <> DWORD(-1) then
+      begin
+        Result := True;
+        hThread := OpenThread(THREAD_SUSPEND_RESUME, False, TID);
+        if hThread <> INVALID_HANDLE_VALUE then
+        begin
+          ResumeThread(hThread);
+          CloseHandle(hThread);
+        end;
+      end;
+    end;
+end;
+
+{$ENDIF BuildThreadSafe}
+
+function MakeProcObj(var Proc; const Obj: Pointer): Boolean;
+{$IFNDEF FPC}
+asm
+  {
+  Default calling convention is :
+  x86 : register .
+  x64 : fastcall.
+  ==>  Do not change ! <==
+  ============================================
+  In order to access TObject variables
+  the compiler need to know the Object
+  that hold this variable .
+
+  When calling TObject.MethodX ,
+  the compiler does not know the TObject
+  So the delphi compiler will use a useful
+  trick .. it will insert the pointer to
+  the object on the EAX/RCX registers .
+
+  eg:Self.DoX(A):
+  MOV EAX,Self
+  MOV EDX,A
+  CALL DoX
+
+  That's mean : the compiler use a specific
+  calling convention to call ObjectMethod
+  => EAX/RCX are always reserved and contains
+  the object pointer value .
+
+  So in order to use Trampoline function
+  we need to make sure that EAX/RCX registers
+  hold the Object pointer value.
+  ============================================
+   }
+
+  {$IFDEF CPUX86}
+  { ->EAX     Proc  . }
+  { ->EDX     Obj   . }
+  { <-AL     Result . }
+  TEST EAX,EAX
+  JE @FAIL
+  TEST EDX,EDX
+  JE @FAIL
+  MOV [EAX+4],EDX
+  {$ELSE !CPUX86}
+  { ->RCX     Proc  . }
+  { ->RDX     Obj   . }
+  { <-AL     Result . }
+  TEST RCX,RCX
+  JE @FAIL
+  TEST RDX,RDX
+  JE @FAIL
+  MOV [RCX+8],RDX
+  {$ENDIF !CPUX86}
+  MOV AL,1   // Result = True
+  JMP @END
+@FAIL:
+  XOR AL,AL // Result = False
+@END:
+end;
+{$ELSE FPC}
+begin
+  Result := False;
+  if Assigned(Pointer(Proc)) and Assigned(Pointer(Obj)) then
+  begin
+    TMethod(Proc).Data := Pointer(Obj);
+    TMethod(Proc).Code := Pointer(Proc);
+    Result := True;
+  end;
+end;
+{$ENDIF FPC}
+
+function InterceptCreate(const TargetProc, InterceptProc: Pointer): Pointer;
+var
+  P: PByte;
+  Inst: TInstruction;
+{$IFDEF BuildThreadSafe }
+  { List that hold the running threads
+    that we had make them suspended ! }
+  RTID: TThreadsListID;
+{$ENDIF BuildThreadSafe}
+begin
+  Result := nil;
+  if Assigned(TargetProc) and Assigned(InterceptProc) then
+  begin
+{$IFDEF BuildThreadSafe }
+    RTID := nil;
+    if OpenThreadExist then
+    begin
+      RTID := TThreadsListID.Create;
+      SuspendAllThreads(RTID);
+    end;
+{$ENDIF BuildThreadSafe}
+    FillChar(Inst, SizeOf(TInstruction), Char(0));
+    P := PByte(TargetProc);
+    P := GetRoot(P, Inst);
+    Result := DoInterceptCreate(P, InterceptProc);
+{$IFDEF BuildThreadSafe }
+    if OpenThreadExist then
+    begin
+      ResumeSuspendedThreads(RTID);
+      RTID.Free;
+    end;
+{$ENDIF BuildThreadSafe}
+  end;
+end;
+
+function InterceptRemove(var Trampoline: Pointer): Boolean;
+var
+  P, Q: PByte;
+  PSave: PSaveData;
+  OrgProcAccess: DWORD;
+  Sb: Byte;
+{$IFDEF BuildThreadSafe }
+  RTID: TThreadsListID;
+{$ENDIF BuildThreadSafe}
+begin
+  Result := False;
+  if Assigned(Trampoline) then
+  begin
+{$IFDEF BuildThreadSafe }
+    RTID := nil;
+    if OpenThreadExist then
+    begin
+      RTID := TThreadsListID.Create;
+      SuspendAllThreads(RTID);
+    end;
+{$ENDIF BuildThreadSafe}
+    Q := Trampoline;
+    PSave := PSaveData(Q);
+    Dec(PByte(PSave), SizeOf(TSaveData));
+    P := PSave^.D2;
+    Dec(P, SizeOfJmp + (Byte(Byte(not PSave^.Size32) and Byte(CPUX = CPUX64)) *
+      SizeOf(Pointer)));
+    Sb := PSave^.Sb;
+    OrgProcAccess := SetMemPermission(P, Sb, PAGE_EXECUTE_READWRITE);
+    CopyInstruction(Q^, P^, Sb);
+    SetMemPermission(P, Sb, OrgProcAccess);
+    Result := VirtualFree(PSave, TrampolineSize, MEM_RELEASE);
+{$IFDEF BuildThreadSafe }
+    if OpenThreadExist then
+    begin
+      ResumeSuspendedThreads(RTID);
+      RTID.Free;
+    end;
+{$ENDIF BuildThreadSafe}
+  end;
+end;
+{ ===================================================== }
+
+{$IFDEF MustUseGenerics }
+
+{ ***** BEGIN LICENSE BLOCK *****
+  *
+  * The initial developer of the original code (TDetour) is David Millington .
+  *
+  * ***** END LICENSE BLOCK ***** }
+{ ----------------------------------------------------- }
+{ TDetour }
+{ ----------------------------------------------------- }
+function TDetour<T>.CheckTType: Boolean;
+var
+  LPInfo: PTypeInfo;
+begin
+  LPInfo := TypeInfo(T);
+  Result := SizeOf(T) = SizeOf(Pointer);
+  if Result then
+    Result := LPInfo.Kind = tkProcedure;
+  if not Result then
+    raise DetourException.Create(Format(SInvalidTType, [LPInfo.Name]));
+end;
+
+constructor TDetour<T>.Create(const TargetProc, InterceptProc: T);
+begin
+  inherited Create();
+  CheckTType;
+  FTargetProc := TToPointer(TargetProc);
+  FInterceptProc := TToPointer(InterceptProc);
+  Assert(Assigned(FTargetProc) and Assigned(FInterceptProc),
+    'Target or replacement methods are not assigned');
+  FTrampoline := T(nil);
+  Enable;
+end;
+
+destructor TDetour<T>.Destroy;
+begin
+  Disable;
+  inherited;
+end;
+
+procedure TDetour<T>.Enable;
+begin
+  if not Installed then
+    FTrampoline := PointerToT(DDetours.InterceptCreate(FTargetProc,
+      FInterceptProc));
+end;
+
+procedure TDetour<T>.Disable;
+var
+  PTrampoline: Pointer;
+begin
+  if Installed then
+  begin
+    PTrampoline := TToPointer(FTrampoline);
+    DDetours.InterceptRemove(PTrampoline);
+    FTrampoline := T(nil);
+  end;
+end;
+
+function TDetour<T>.GetInstalled: Boolean;
+begin
+  Result := Assigned(TToPointer(FTrampoline));
+end;
+
+function TDetour<T>.GetTrampoline: T;
+begin
+  Assert(Installed, 'Detour is not installed; trampoline pointer is nil');
+  Result := FTrampoline;
+end;
+
+function TDetour<T>.PointerToT(const P: Pointer): T;
+{ var
+  Trampoline: Pointer;
+  Method: T absolute Trampoline; }
+begin
+  // Cannot cast from Pointer to T (even though intended use of this class is for T to be a method
+  // type - there is no constraint for this though) so hack it via absolute
+  // Trampoline := P;
+  // Result := Method;
+  Result := TGenericsCast<Pointer, T>.Cast(P);
+end;
+
+function TDetour<T>.TToPointer(const AT: T): Pointer;
+{ var
+  Method: T;
+  Trampoline: Pointer absolute Method; }
+begin
+  // Cannot cast from Pointer to T (even though intended use of this class is for T to be a method
+  // type - there is no constraint for this though) so hack it via absolute
+  // Method := AT;
+  // Result := Trampoline;
+  Result := TGenericsCast<T, Pointer>.Cast(AT);
+end;
+
+{$ENDIF MustUseGenerics}
+{ ===================================================== }
+
+{$IFDEF BuildThreadSafe }
+{ ----------------------------------------------------- }
+{ TThreadsListID }
+{ ----------------------------------------------------- }
+
+constructor TThreadsListID.Create;
+begin
+  FPointer := nil;
+  FSize := 0;
+end;
+
+destructor TThreadsListID.Destroy;
+begin
+  if Assigned(FPointer) then
+    FreeMem(FPointer);
+  inherited;
+end;
+
+procedure TThreadsListID.Add(const Value: DWORD);
+var
+  Delta: UINT;
+begin
+  if not Assigned(FPointer) then
+  begin
+    { First Item ! }
+    GetMem(FPointer, SizeOf(DWORD));
+    FCount := 0;
+    FSize := 0;
+  end
+  else
+    Inc(FCount); // Not first item !
+
+  { Calculate the delta position between the memory that will
+    hold the value and the pointer value (FPointer). }
+  Delta := FCount shl 2; // FCount * SizeOf(DWORD);
+
+  if Delta <> 0 then
+    ReallocMem(FPointer, Delta + SizeOf(DWORD));
+
+  Inc(PByte(FPointer), Delta);
+  PDWORD(FPointer)^ := Value;
+
+  { Always restore the previous pointer value }
+  Dec(PByte(FPointer), Delta);
+  Inc(FSize, SizeOf(DWORD)); // Size in bytes that is being used .
+end;
+
+function TThreadsListID.GetID(const Index: UINT): DWORD;
+var
+  Delta: UINT;
+begin
+  Result := DWORD(-1); // Default result when fail .
+
+  Delta := Index shl 2; // Index * SizeOf(DWORD) ;
+
+  // if (Delta >= 0) and (Delta < FSize) and (Index >= 0) and (Index <= FCount) then
+  if (Delta < FSize) and (Index <= FCount) then
+  begin
+    { Not out of range ! }
+    Inc(PByte(FPointer), Delta);
+    Result := PDWORD(FPointer)^;
+
+    { Always restore the previous pointer value }
+    Dec(PByte(FPointer), Delta);
+  end;
+end;
+
+initialization
+
+{$IFDEF FPC}
+  OpenThread := nil;
+{$ELSE !FPC}
+  @OpenThread := nil;
+{$ENDIF !FPC}
+FreeKernel := False;
+
+hKernel := GetModuleHandle(kernel32);
+if hKernel <= 0 then
+begin
+  hKernel := LoadLibrary(kernel32);
+  FreeKernel := (hKernel > 0);
+end;
+if hKernel > 0 then
+begin
+{$IFDEF FPC}
+  Pointer(OpenThread) := GetProcAddress(hKernel, 'OpenThread');
+  Pointer(CreateToolhelp32Snapshot) := GetProcAddress(hKernel,
+    'CreateToolhelp32Snapshot');
+  Pointer(Thread32First) := GetProcAddress(hKernel, 'Thread32First');
+  Pointer(Thread32Next) := GetProcAddress(hKernel, 'Thread32Next');
+{$ELSE !FPC}
+  @OpenThread := GetProcAddress(hKernel, 'OpenThread');
+{$ENDIF !FPC}
+end;
+{ The OpenThread function does not exist on OS version < Win XP }
+OpenThreadExist := (@OpenThread <> nil);
+
+finalization
+
+if (FreeKernel) and (hKernel > 0) then
+  FreeLibrary(hKernel);
+{$ENDIF BuildThreadSafe}
+
+end.

--- a/Source/DDetours/GenericsCast.pas
+++ b/Source/DDetours/GenericsCast.pas
@@ -1,0 +1,46 @@
+// **************************************************************************************************
+// Delphi Detours Library
+// Unit GenericsCast
+// http://code.google.com/p/delphi-detours-library/
+
+// The contents of this file are subject to the Mozilla Public License Version 1.1 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.mozilla.org/MPL/
+//
+// Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
+// ANY KIND, either express or implied. See the License for the specific language governing rights
+// and limitations under the License.
+//
+// The Original Code is GenericsCast.pas.
+// The Initial Developer of the Original Code is Mahdi Safsafi [SMP3].
+// Portions created by Mahdi Safsafi . are Copyright (C) 2013-2014 Mahdi Safsafi .
+// All Rights Reserved.
+//
+// **************************************************************************************************
+
+unit GenericsCast;
+
+interface
+
+uses
+  System.Math, WinApi.Windows;
+
+type
+  { T = Type ; TT = ToType }
+TGenericsCast < T, TT >= class(TObject)
+/// <summary> Cast T type to TT type .
+/// </summary>
+  class function Cast(const T: T): TT;
+end;
+
+implementation
+
+{ TGenericsCast<T, TT> }
+
+class function TGenericsCast<T, TT>.Cast(const T: T): TT;
+begin
+  Result := Default (TT);
+  CopyMemory(@Result, @T, Min(SizeOf(T), SizeOf(TT)));
+end;
+
+end.

--- a/Source/DDetours/InstDecode.pas
+++ b/Source/DDetours/InstDecode.pas
@@ -1,0 +1,678 @@
+// **************************************************************************************************
+// Delphi Instruction Decode Library
+// Unit InstDecode
+// http://code.google.com/p/delphi-detours-library/
+
+// The contents of this file are subject to the Mozilla Public License Version 1.1 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.mozilla.org/MPL/
+//
+// Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
+// ANY KIND, either express or implied. See the License for the specific language governing rights
+// and limitations under the License.
+//
+// The Original Code is InstDecode.pas.
+//
+// The Initial Developer of the Original Code is Mahdi Safsafi [SMP3].
+// Portions created by Mahdi Safsafi . are Copyright (C) 2013-2014 Mahdi Safsafi .
+// All Rights Reserved.
+//
+// **************************************************************************************************
+
+unit InstDecode;
+
+interface
+
+uses Windows;
+
+{$I dDefs.inc}
+
+type
+  PPrefixes = ^TPrefixes;
+
+  TPrefixes = packed record
+    Count: Byte; // Numbers of prefixes used by the instruction .
+    case Integer of
+      0: (Pref1, Pref2, Pref3, Pref4: Byte);
+      1: (Prefixes: Array [0 .. 4 - 1] of Byte);
+      2: (Value: DWORD);
+  end;
+
+  PModRM = ^TModRM;
+
+  TModRM = record
+    Used: Boolean; { True if instruction use ModRM . }
+    Value: Byte; { Value of ModRM . }
+    rMod: Byte; { Mod field value . }
+    rReg: Byte; { Reg field value . }
+    rRM: Byte; { RM field value . }
+    OpExt: Boolean; { True if  ModRM store OpCode extension . }
+  end;
+
+  PSIB = ^TSIB;
+
+  TSIB = packed record
+    Used: Boolean;
+    Scale: Byte;
+    Index: Byte;
+    Base: Byte;
+    Value: Byte;
+  end;
+
+  PDisplacement = ^TDisplacement;
+
+  TDisplacement = packed record
+    Used: Boolean; { True if instruction use Displacement . }
+    i32: Boolean; { True if size of Displacement = 32 bit ; otherwise False : size of Displacement = 8 bit }
+    Value: Integer; { Displacement value . }
+    Relative: Boolean; { True if Displacement is Relative => only for x64 bit . }
+  end;
+
+  PImmediate = ^TImmediate;
+
+  TImmediate = packed record
+    Used: Boolean; { True if instruction use Immediate . }
+    SizeOfImmediate: Byte; { Size Of Immediate Value [1,2,4,8] bytes . }
+    Value: Int64; { Value of Immediate . }
+  end;
+
+  PJumpCall = ^TJumpCall;
+
+  TJumpCall = packed record
+    Used: Boolean; { True if instruction is JUMP or CALL . }
+    JumpUsed: Boolean; { True if instruction is JUMP . }
+    CallUsed: Boolean; { True if instruction is CALL . }
+    Relative: Boolean; { True if instruction use Relative offset . }
+    IndirectDispOnly: Boolean; { True if JUMP/CALL Indirect Disp only => JMP [123456] }
+    IndirectReg: Boolean; { True if JUMP/CALL Indirect  => JMP [EAX]; JMP [EAX + 123456] }
+    OffsetSize: Byte; { Size of Offset . }
+    Offset: Integer; { Offset value . }
+    Address: UInt64; { Destination address . }
+  end;
+
+  TOpCodeParams = packed record
+    nOp: Byte; // Numbers of operands .
+    Op1: DWORD; // Operand 1 flags .
+    Op2: DWORD; // Operand 2 flags .
+    Op3: DWORD; // Operand 3 flags .
+    Op4: DWORD; // Operand 4 flags .
+  end;
+
+  PInstruction = ^TInstruction;
+
+  TInstruction = packed record
+    Address: Pointer; { Current Address }
+    Mod16: Boolean; { True if size of operand =  16 bit }
+    Mod64: Boolean; { True if size of operand =  64 bit }
+    Prefixes: TPrefixes; { Prefixes }
+    OpCode: Word; { OpCode }
+    nOpCode: Byte; { Numbers of OpCode ==> Max = 3 }
+    SOpCode: Byte; { Secondary OpCode Value }
+    SOpUsed: Boolean; { True if Secondary OpCode Used . }
+    Params: TOpCodeParams; { Operand Params }
+    ModRM: TModRM; { ModRM }
+    SIB: TSIB; { SIB }
+    Displacement: TDisplacement; { Displacement }
+    Immediate: TImmediate; { Immediate }
+    JumpCall: TJumpCall; { JumpCall }
+    InstSize: ShortInt; { Instruction Size }
+    NextInst: Pointer; { Pointer to the next instruction . }
+  end;
+
+const
+  { preffixes codes }
+  { Prefix group 1 }
+  prefLock = $F0;
+  prefRepn = $F2;
+  prefRep = $F3;
+  { Prefix group 2 }
+  prefCS = $2E;
+  prefSS = $36;
+  prefDS = $3E;
+  prefES = $26;
+  prefFS = $64;
+  prefGS = $65;
+  pref2E = $2E; // Branch not taken
+  pref3E = $3E; // Branch taken
+  { Prefix group 3 }
+  prefSize66 = $66; // Operand-size override prefix ==>Operand 16bit .
+  { Prefix group 4 }
+  prefAdd67 = $67; // Address-size override prefix
+  prefSize48 = $48; // Operand-size override prefix ==>Operand 64bit .
+
+  Max_Inst_Len32 = 17; // 4 Prefix + 2 Byte OpCode + 1 Second OpCode + 1 Byte ModRM + 1 SIB + 4 Byte Disp + 4 Byte Imm.
+  Max_Inst_Len64 = 21; // 4 Prefix + 2 Byte OpCode + 1 Second OpCode + 1 Byte ModRM + 1 SIB + 4 Byte Disp + 8 Byte Imm.
+
+type
+  TCPUX = (CPUX32, CPUX64);
+
+function DecodeInstruction(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): ShortInt;
+function GetMaxInstLen(const CPUX: TCPUX): ShortInt;
+
+{$IFNDEF FPC}
+{$IF CompilerVersion <25}
+
+{ dcc < XE4 }
+type
+  PShort = ^SHORT;
+  PUInt64 = ^UInt64;
+{$IFEND}
+{$ELSE FPC}
+
+type
+  // PShort = ^SHORT;
+  PUInt64 = ^UInt64;
+
+{$ENDIF FPC}
+
+implementation
+
+{$I OpCodesTables.inc}
+{$I ModRMTable.inc}
+
+type
+  PSysEAJump = ^TSysEAJump;
+
+  TSysEAJump = packed record
+    D: DWORD;
+    W: Word;
+  end;
+
+{$WARN NO_RETVAL OFF}
+
+function GetMaxInstLen(const CPUX: TCPUX): ShortInt;
+begin
+  case CPUX of
+    CPUX32: Result := Max_Inst_Len32;
+    CPUX64: Result := Max_Inst_Len64;
+  end;
+end;
+
+function GetBit(const Value: Cardinal; const nBit: Byte): Boolean;
+begin
+  Result := (Value and (1 shl nBit)) <> 0;
+end;
+
+function GetMod(const ModRegRM: Byte): Byte; {$IFDEF MustInline}inline; {$ENDIF}
+begin
+  Result := ModRegRM shr 6;
+end;
+
+function GetReg(const ModRegRM: Byte): Byte; {$IFDEF MustInline}inline; {$ENDIF}
+begin
+  Result := Byte(ModRegRM shl 2);
+  Result := Result shr 5;
+end;
+
+function GetRM(const ModRegRM: Byte): Byte; {$IFDEF MustInline}inline; {$ENDIF}
+begin
+  { Result := (ModRegRM shl 5);
+    Result := Result shr 5; }
+  Result := ModRegRM and 7;
+end;
+
+function GetScale(const SIB: Byte): Byte; {$IFDEF MustInline}inline; {$ENDIF}
+begin
+  Result := SIB shr 6;
+  case Result of
+    { 00b } 0: Result := 1;
+    { 01b } 1: Result := 2;
+    { 10b } 2: Result := 4;
+    { 11b } 3: Result := 8;
+  end;
+end;
+
+function GetIndex(const SIB: Byte): Byte; {$IFDEF MustInline}inline; {$ENDIF}
+begin
+  Result := Byte(SIB shl 2);
+  Result := Result shr 5;
+end;
+
+function GetBase(const SIB: Byte): Byte; {$IFDEF MustInline}inline; {$ENDIF}
+begin
+  { Result := (SIB shl 5);
+    Result := Result shr 5; }
+  Result := SIB and 7;
+end;
+
+{$HINTS OFF}
+
+function DecodePreffixes(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): Byte;
+var
+  i: Integer;
+  P: PByte;
+  PrefixUsed: Boolean;
+begin
+  Result := 0;
+  P := PByte(Addr);
+  Inst^.Prefixes.Count := 0;
+  Inst^.Prefixes.Value := 0;
+  Inst^.Mod16 := False;
+  Inst^.Mod64 := False;
+  PrefixUsed := False;
+
+  for i := 0 to 3 do
+  begin
+    PrefixUsed := P^ in [prefLock, prefRepn, prefRep, prefCS, prefSS, prefDS, prefES, prefFS, prefGS {$IFNDEF FPC}, pref2E, pref3E{$ENDIF}, prefSize66, prefAdd67];
+    if not PrefixUsed then
+      if CPUX = CPUX64 then
+      begin
+        PrefixUsed := (P^ = prefSize48);
+        if PrefixUsed then
+          Inst^.Mod64 := True;
+      end;
+    if PrefixUsed then
+    begin
+      Inst^.Prefixes.Prefixes[i] := P^;
+      Inc(Result);
+      if P^ = prefSize66 then
+        Inst^.Mod16 := True;
+    end
+    else
+      Break;
+    Inc(P);
+  end;
+  Inst^.Prefixes.Count := Result;
+end;
+{$HINTS ON}
+
+function GetEntryOpCode(const Opw: Word): TOpCodeEntryInfo;
+var
+  Op: Byte;
+begin
+  FillChar(Result, SizeOf(TOpCodeEntryInfo), #0);
+  Op := Byte(Opw);
+  if Op = $0F then
+    Result := TwoByteOpCodesEntry[HiByte(Opw)]
+  else
+    Result := OneByteOpCodesEntry[Op];
+end;
+
+function DecodeOpCode(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): Byte;
+var
+  P: PByte;
+  Entry: TOpCodeEntryInfo;
+  n: Byte;
+  Op, SOp: Byte;
+  SOpUsed: BOOL;
+begin
+  P := PByte(Addr);
+  Result := 1; // Default for one byte OpCode .
+  Inst^.nOpCode := 1;
+  if P^ = $0F then
+  begin
+    { Two bytes OpCode }
+    Inst^.nOpCode := 2;
+    Inst^.OpCode := PWORD(P)^;
+    Inc(Result);
+  end
+  else
+    Inst^.OpCode := PByte(P)^; // One byte OpCode .
+
+  Entry := GetEntryOpCode(Inst^.OpCode);
+  n := 0; // Number of operands .
+  if Entry.Op1 <> Op_NONE then
+    Inc(n);
+  if Entry.Op2 <> Op_NONE then
+    Inc(n);
+  if Entry.Op3 <> Op_NONE then
+    Inc(n);
+  if Entry.Op4 <> Op_NONE then
+    Inc(n);
+
+  { Operands Flags }
+  Inst^.Params.Op1 := Entry.Op1;
+  Inst^.Params.Op2 := Entry.Op2;
+  Inst^.Params.Op3 := Entry.Op3;
+  Inst^.Params.Op4 := Entry.Op4;
+  Inst^.Params.nOp := n;
+
+  SOp := 0;
+  SOpUsed := False;
+  if P^ = $0F then
+  begin
+    Inc(P);
+    Op := P^; // Primary OpCode .
+    Inc(P);
+    SOp := P^; // Secondary OpCode .
+    case Op of
+      $01: SOpUsed := SOp in [$C1 .. $C4, $C8 .. $C9, $D0 .. $D1, $F8 .. $F9];
+      $38, $39: SOpUsed := SOp in [$00 .. $B, $10, $14 .. $15, $17, $1C, $1D, $1E, $20 .. $25, $28 .. $2B, $30 .. $35, $37 .. $41, $80 .. $81, $F0 .. $F1];
+      $3A: SOpUsed := SOp in [$8 .. $F, $14 .. $17, $20 .. $22, $40 .. $42, $60 .. $63];
+    else SOpUsed := False;
+    end;
+  end;
+
+  { If Secondary OpCode is used . }
+  if SOpUsed then
+  begin
+    Inst^.SOpCode := SOp;
+    Inc(Inst^.nOpCode);
+    Inc(Result);
+  end
+  else
+    Inst^.SOpCode := 0;
+  Inst^.SOpUsed := SOpUsed;
+end;
+
+function DecodeSIB(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): Byte;
+var
+  SIB: Byte;
+begin
+  Result := 0;
+  // Inst^.SIB.Used := ((Inst^.ModRM.rMod < 3) and (Inst^.ModRM.rRM = 4));
+  SIB := PByte(Addr)^;
+  if Inst^.SIB.Used then
+  begin
+    Inst^.SIB.Value := SIB;
+    Inst^.SIB.Scale := GetScale(SIB);
+    Inst^.SIB.Index := GetIndex(SIB);
+    Inst^.SIB.Base := GetBase(SIB);
+    Inc(Result); // SIB Used .
+  end;
+end;
+
+function DecodeModRM(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): Byte;
+var
+  P: PByte;
+  Flags: Byte;
+  Entry: TOpCodeEntryInfo;
+  ModRM, ModRMF: Byte;
+begin
+  Result := 0;
+  P := PByte(Addr);
+  Entry := GetEntryOpCode(Inst^.OpCode);
+  Flags := Entry.Flags;
+  Inst^.SIB.Used := False;
+
+  { if Inst^.ModRM.OpExt => Reg field contain opcode extension . }
+  Inst^.ModRM.OpExt := (Flags and Opf_ModRMExt = Opf_ModRMExt);
+
+  if Flags and Opf_ModRM = Opf_ModRM then
+  begin
+    { ModRM Used . }
+    ModRM := P^;
+    Inst^.ModRM.Used := True;
+    Inst^.ModRM.rMod := GetMod(ModRM);
+    Inst^.ModRM.rRM := GetRM(ModRM);
+    Inst^.ModRM.rReg := GetReg(ModRM);
+    Inst^.ModRM.Value := ModRM;
+    Inc(Result);
+    Inc(P);
+    ModRMF := ModRMFlags[ModRM]; // ModRM Flags.
+    if ModRMF in [8, $B, $D] then // SIB is used ! => See ModRMFlags .
+    begin
+      Inst^.SIB.Used := True;
+      Inc(Result, DecodeSIB(P, Inst, CPUX));
+    end;
+  end;
+end;
+
+function DecodeJump(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): Byte;
+var
+  P: PByte;
+  Q: Pointer;
+  Opf: Byte;
+  Jbf: DWORD;
+  Entry: TOpCodeEntryInfo;
+  Value: UInt64;
+  Size: Byte;
+  DstAddr: UInt64;
+  SysEAJump: PSysEAJump;
+begin
+  Result := 0;
+  Size := 0;
+  Entry := GetEntryOpCode(Inst^.OpCode);
+  Jbf := 0;
+  Opf := Entry.Flags;
+  P := PByte(Addr);
+  if (Inst^.OpCode = $FF) and (Inst^.ModRM.Used) and (Inst^.ModRM.rReg > 1) and (Inst^.ModRM.rReg < 6) then
+  begin
+    { Absolute Indirect JMP }
+    Inst^.JumpCall.Used := True;
+    Inst^.JumpCall.CallUsed := Inst^.ModRM.rReg in [2, 3]; // CALL instruction .
+    Inst^.JumpCall.JumpUsed := Inst^.ModRM.rReg in [4, 5]; // JMP instruction .
+    if (Inst^.ModRM.rMod = 00) then
+    begin
+      Inst^.JumpCall.IndirectDispOnly := False;
+      Inst^.JumpCall.IndirectReg := True; // JMP [EAX] .
+      Inst^.JumpCall.OffsetSize := 4;
+      if (Inst^.ModRM.rRM = 5) and (Inst^.Displacement.Used) then
+      begin
+        Q := Pointer(Inst^.Displacement.Value);
+        Inst^.JumpCall.IndirectReg := False;
+        Inst^.JumpCall.IndirectDispOnly := True; // JMP DWORD Ptr [Address]; where Address = Destination .
+        if CPUX = CPUX32 then
+        begin
+          { E.g :
+            DW 401591  = 401792.
+            JMP DWORD PTR DS:[401591] .
+            Offset = 401591 .
+            Address = Pointer to the address stored on the Offset value = 401792 .
+          }
+          Inst^.JumpCall.Address := UINT(Q^);
+          Inst^.JumpCall.Offset := Integer(Inst^.Displacement.Value);
+        end
+        else
+        begin
+          { E.g :
+            Distination = $76A6A418 .
+            JMP QWORD  PTR [REL $002d079a]
+            $002d079a = Difference between EIP and the variable (V) that hold the distination address pointer.
+            @V:= EIP + 4 bytes (SizeOf Rel offset=> SizeOf(002d079a)= 4 Bytes) + offset value (002d079a).
+            Distination := V^ => Value stored on the variable V .
+          }
+          Inst^.JumpCall.Address := UInt64(Pointer(UInt64(P) + 4 + UInt64(Q))^);
+          Inst^.JumpCall.Offset := Integer(Inst^.Displacement.Value);
+        end;
+      end;
+    end;
+    Exit;
+  end;
+
+  if Opf and Opf_Jump = Opf_Jump then
+  begin
+    if (Entry.Op1 and Op_J = Op_J) or (Entry.Op1 and Op_Ap = Op_Ap) then
+      Jbf := Entry.Op1
+    else if (Entry.Op2 and Op_J = Op_J) or (Entry.Op2 and Op_Ap = Op_Ap) then
+      Jbf := Entry.Op2;
+
+    if Jbf and Op_J = Op_J then // Jump used .
+    begin
+      { Relative JMP }
+      Inst^.JumpCall.Used := True;
+      Inst^.JumpCall.Relative := True;
+      if Jbf and Op_Jbs = Op_Jbs then
+      begin
+        Inst^.JumpCall.Offset := PShortInt(P)^;
+        Size := 1;
+      end
+      else if Jbf and Op_Jvds = Op_Jvds then
+      begin
+        Size := 2;
+        if Inst^.Mod16 then
+          Inst^.JumpCall.Offset := PShort(P)^
+        else
+        begin
+          Size := 4;
+          Inst^.JumpCall.Offset := PInteger(P)^
+        end;
+      end;
+      if Size > 0 then
+      begin
+        Inst^.JumpCall.OffsetSize := Size;
+        DstAddr := UInt64(Inst^.Address);
+        DstAddr := DstAddr + Inst^.JumpCall.Offset + Inst^.nOpCode { OpCodes } + Size;
+        Inst^.JumpCall.Address := DstAddr;
+        Result := Size;
+      end;
+    end
+    else if Jbf and Op_Ap = Op_Ap then
+    begin
+      { Used only by the System ! }
+      Inst^.JumpCall.Relative := False;
+      Inst^.JumpCall.IndirectDispOnly := False;
+      if Inst^.Mod16 then
+      begin
+        Result := 4;
+        Inst^.JumpCall.OffsetSize := 4;
+        Inst^.JumpCall.Address := PDWORD(P)^;
+      end
+      else
+      begin
+        Result := 6;
+        Inst^.JumpCall.OffsetSize := 6;
+        SysEAJump := PSysEAJump(P);
+        Value := UInt64(SysEAJump^.W);
+        Value := UInt64(Value shl 32);
+        Value := UInt64(Value or SysEAJump^.D);
+        Inst^.JumpCall.Address := Value;
+      end;
+    end;
+  end;
+end;
+
+function DecodeDisplacement(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): Byte;
+var
+  Size: Byte;
+  ModRMF: Byte;
+begin
+  Size := 0;
+  Result := 0;
+  if Inst^.ModRM.Used then
+  begin
+    Inst^.Displacement.Relative := (CPUX = CPUX64) and (Inst^.ModRM.rMod = 00) and (Inst^.ModRM.rRM = 5);
+    {
+      Relative Displacement only for x64 !
+      e.g : MOV RAX ,[REL 123456]
+    }
+    ModRMF := ModRMFlags[Inst^.ModRM.Value];
+    case ModRMF of
+      00, 01: Exit; // No Disp.
+      03, $B: Size := 1; // 8 Bit Disp .
+      05, 08, $D: Size := 4; // 32 Bit Disp .
+    end;
+  end;
+  if Size = 1 then
+    Inst^.Displacement.Value := PShortInt(Addr)^
+  else if Size = 4 then
+    Inst^.Displacement.Value := PInteger(Addr)^;
+
+  Inst^.Displacement.Used := (Size > 0);
+  Inst^.Displacement.i32 := (Size = 4);
+  Inc(Result, Size);
+  Inc(Result, DecodeJump(Addr, Inst, CPUX));
+end;
+
+function DecodeImmediate(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): Byte;
+var
+  P: PByte;
+  Entry: TOpCodeEntryInfo;
+  immf: DWORD;
+  Size: Byte;
+begin
+  P := PByte(Addr);
+  Result := 0;
+  Inst^.Immediate.Used := False;
+  Entry := GetEntryOpCode(Inst^.OpCode);
+  immf := 0;
+  Size := 0;
+  if Inst^.JumpCall.Used then
+    Exit;
+  try
+    { Check if data is used ! }
+    if (Entry.Op1 and Op_Imm = Op_Imm) then
+      immf := Entry.Op1
+    else if (Entry.Op2 and Op_Imm = Op_Imm) then
+      immf := Entry.Op2
+    else if (Entry.Op3 and Op_Imm = Op_Imm) then
+      immf := Entry.Op3
+    else if (Entry.Op4 and Op_Imm = Op_Imm) then
+      immf := Entry.Op4;
+
+    if immf > 0 then
+    begin
+      { Yes ,there is data (Immediate) }
+      Inst^.Immediate.Used := True;
+      if (immf and Op_Ivqp = Op_Ivqp) or (immf and Op_Ivs = Op_Ivs) then
+      begin
+        Size := 2; // Smaller size = SizeOf(WORD)= 2 Bytes .
+        if not Inst^.Mod16 then
+          Inc(Size, 2); // 32 bit data .
+        if Inst^.Mod64 then
+          Inc(Size, 4); // 64 bit data .
+        Exit;
+      end
+      else if immf and Op_Iw = Op_Iw then
+        Size := 2 // 16 bit data .
+      else if immf and Op_Ib = Op_Ib then
+        Size := 1 // 8 bit data .
+    end;
+  finally
+    if Size > 0 then
+    begin
+      Inst^.Immediate.SizeOfImmediate := Size;
+      { Get Immediate value }
+      if (immf and Op_SignExt = Op_SignExt) or (Entry.Flags and Opf_S = Opf_S) then
+      begin
+        { Sign-extend .eg :PUSH -5 }
+        if Size = 8 then
+          Inst^.Immediate.Value := PInt64(P)^
+        else if Size = 4 then
+          Inst^.Immediate.Value := PInteger(P)^
+        else if Size = 2 then
+          Inst^.Immediate.Value := PShort(P)^
+        else // Size = 1 .
+          Inst^.Immediate.Value := PShortInt(P)^;
+      end
+      else
+      begin
+        if Size = 8 then
+          Inst^.Immediate.Value := PUInt64(P)^
+        else if Size = 4 then
+          Inst^.Immediate.Value := PDWORD(P)^
+        else if Size = 2 then
+          Inst^.Immediate.Value := PWORD(P)^
+        else // Size = 1 .
+          Inst^.Immediate.Value := PByte(P)^;
+      end;
+      Inc(Result, Size);
+    end;
+  end;
+end;
+
+function DecodeInstruction(const Addr: Pointer; const Inst: PInstruction; const CPUX: TCPUX): ShortInt;
+var
+  P: PByte;
+  Size: ShortInt;
+begin
+  Result := 0;
+  P := PByte(Addr);
+  Inst^.Address := Addr;
+  Size := DecodePreffixes(P, Inst, CPUX);
+  Inc(Result, Size);
+  Inc(P, Size);
+  Size := DecodeOpCode(P, Inst, CPUX);
+  Inc(Result, Size);
+  Inc(P, Size);
+  Size := DecodeModRM(P, Inst, CPUX);
+  Inc(Result, Size);
+  Inc(P, Size);
+  Size := DecodeDisplacement(P, Inst, CPUX);
+  Inc(Result, Size);
+  Inc(P, Size);
+  Size := DecodeImmediate(P, Inst, CPUX);
+  Inc(Result, Size);
+
+  if Result > GetMaxInstLen(CPUX) then
+  begin
+    Result := -1;
+    Exit;
+  end;
+
+  Inst^.InstSize := Result;
+  Inc(P, Result);
+  Inst^.NextInst := P;
+end;
+
+end.

--- a/Source/DDetours/ModRMTable.inc
+++ b/Source/DDetours/ModRMTable.inc
@@ -1,0 +1,80 @@
+// **************************************************************************************************
+// This file (ModRMTable.inc) is a part of the InstDecode Library .
+// File ModRMTable
+// http://code.google.com/p/delphi-detours-library/
+
+// The contents of this file are subject to the Mozilla Public License Version 1.1 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.mozilla.org/MPL/
+//
+// Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
+// ANY KIND, either express or implied. See the License for the specific language governing rights
+// and limitations under the License.
+//
+// The Original Code is ModRMTable.inc .
+//
+// The Initial Developer of the Original Code is Mahdi Safsafi [SMP3].
+// Portions created by Mahdi Safsafi . are Copyright (C) 2013-2014 Mahdi Safsafi .
+// All Rights Reserved.
+//
+// **************************************************************************************************
+
+{ Reference : Intel® 64 and IA-32 Architectures Software Developer’s Manual Vol 2 }
+
+{
+  ModRMFlags :
+  Bits: 3 2 1 0 .
+  Bit 0 : Set ==> Register Indirect Addressing Mode  .
+  Bit 1 : Set ==> Displacement 8 bit .
+  Bit 2 : Set ==> Displacement 32 bit .
+  Bit 3 : Set ==> SIB Used .
+
+  Values:
+  $0 => Register Addressing Mode .
+  $1 => Register Indirect Addressing Mode with No Displacement .
+  $3 => Register Indirect Addressing Mode + 8 bit Displacement .
+  $5 => Register Indirect Addressing Mode + 32 bit Displacement .
+  $8 => SIB is Used .
+  $B => Register Indirect Addressing Mode + SIB + 8 bit Displacement .
+  $D => Register Indirect Addressing Mode + SIB + 32 bit Displacement .
+}
+const
+  ModRMFlags: array [0 .. $FF] of Byte = (
+    { =>        Mod=00b       <= }
+    1, 1, 1, 1, 8, 5, 1, 1, { 00 }
+    1, 1, 1, 1, 8, 5, 1, 1, { 00 }
+    1, 1, 1, 1, 8, 5, 1, 1, { 00 }
+    1, 1, 1, 1, 8, 5, 1, 1, { 00 }
+    1, 1, 1, 1, 8, 5, 1, 1, { 00 }
+    1, 1, 1, 1, 8, 5, 1, 1, { 00 }
+    1, 1, 1, 1, 8, 5, 1, 1, { 00 }
+    1, 1, 1, 1, 8, 5, 1, 1, { 00 }
+    { =>        Mod=01b       <= }
+    3, 3, 3, 3, $B, 3, 3, 3, { 01 }
+    3, 3, 3, 3, $B, 3, 3, 3, { 01 }
+    3, 3, 3, 3, $B, 3, 3, 3, { 01 }
+    3, 3, 3, 3, $B, 3, 3, 3, { 01 }
+    3, 3, 3, 3, $B, 3, 3, 3, { 01 }
+    3, 3, 3, 3, $B, 3, 3, 3, { 01 }
+    3, 3, 3, 3, $B, 3, 3, 3, { 01 }
+    3, 3, 3, 3, $B, 3, 3, 3, { 01 }
+    { =>        Mod=10b       <= }
+    5, 5, 5, 5, $D, 5, 5, 5, { 10 }
+    5, 5, 5, 5, $D, 5, 5, 5, { 10 }
+    5, 5, 5, 5, $D, 5, 5, 5, { 10 }
+    5, 5, 5, 5, $D, 5, 5, 5, { 10 }
+    5, 5, 5, 5, $D, 5, 5, 5, { 10 }
+    5, 5, 5, 5, $D, 5, 5, 5, { 10 }
+    5, 5, 5, 5, $D, 5, 5, 5, { 10 }
+    5, 5, 5, 5, $D, 5, 5, 5, { 10 }
+    { =>        Mod=11b       <= }
+    0, 0, 0, 0, 0, 0, 0, 0, { 11 }
+    0, 0, 0, 0, 0, 0, 0, 0, { 11 }
+    0, 0, 0, 0, 0, 0, 0, 0, { 11 }
+    0, 0, 0, 0, 0, 0, 0, 0, { 11 }
+    0, 0, 0, 0, 0, 0, 0, 0, { 11 }
+    0, 0, 0, 0, 0, 0, 0, 0, { 11 }
+    0, 0, 0, 0, 0, 0, 0, 0, { 11 }
+    0, 0, 0, 0, 0, 0, 0, 0 { 11 }
+
+    );

--- a/Source/DDetours/OpCodesTables.inc
+++ b/Source/DDetours/OpCodesTables.inc
@@ -1,0 +1,761 @@
+// **************************************************************************************************
+// This file (OpCodesTables.inc) is a part of the InstDecode Library .
+// File OpCodesTables
+// http://code.google.com/p/delphi-detours-library/
+
+// The contents of this file are subject to the Mozilla Public License Version 1.1 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy of the
+// License at http://www.mozilla.org/MPL/
+//
+// Software distributed under the License is distributed on an "AS IS" basis, WITHOUT WARRANTY OF
+// ANY KIND, either express or implied. See the License for the specific language governing rights
+// and limitations under the License.
+//
+// The Original Code is OpCodesTables.inc .
+//
+// The Initial Developer of the Original Code is Mahdi Safsafi [SMP3].
+// Portions created by Mahdi Safsafi . are Copyright (C) 2013-2014 Mahdi Safsafi .
+// All Rights Reserved.
+//
+// **************************************************************************************************
+
+{
+  Reference : ref.x86asm.net
+
+}
+const
+  { OpCode Flags }
+  Opf_NONE = $0;
+  Opf_W = $1; // bit w (bit index 0, operand size) is present.
+  Opf_D = $2; // bit d (bit index 1, Direction) is present.
+  Opf_S = $4; // bit s (bit index 1, Sign-extend) is present.
+  Opf_L = $8; // Instruction can use lock prefix .
+  Opf_ModRM = $10; // Instruction use ModRM .
+  Opf_ModRMExt = Opf_ModRM or $20; // Instruction use ModRMExt.
+  Opf_Jump = $40;
+  { ------------------->Operand Flags <------------------ }
+  {
+    A  =  Direct address. The instruction has no ModR/M byte; the address of the operand is encoded in the instruction; no base register, index register, or scaling factor can be applied (for example, far JMP (EA)).
+    E  =  ModR/M specifies the operand (general-purpose register or a memory address) .
+    G  =  general-purpose register .
+    J  = The instruction contains a relative offset to be added to the instruction pointer register (for example, JMP ).
+    M  =  The ModR/M byte may refer only to memory: mod <> 11bin .
+    O  =  The instruction has no ModR/M byte; the offset of the operand is coded as a word, double word or quad word (depending on address size attribute) in the instruction. No base register, index register, or scaling factor can be applied (only MOV  (A0, A1, A2, A3)).
+    S  =  The reg field of the ModR/M byte selects a segment register (only MOV (8C, 8E)).
+    U  =  The R/M field of the ModR/M byte selects a 128-bit XMM register.
+    D  =  The reg field of the ModR/M byte selects a debug register (only MOV (0F21, 0F23)).
+    R  =  The mod field of the ModR/M byte may refer only to a general register .
+    T  =  The reg field of the ModR/M byte selects a test register (only MOV (0F24, 0F26)).
+    Z  =  The instruction has no ModR/M byte; the three least-significant bits of the opcode byte selects a general-purpose register .
+
+    a  =  Two one-word operands in memory or two double-word operands in memory, depending on operand-size attribute (only BOUND).
+    b  =  BYTE .
+    bs =  Byte, sign-extended to the size of the destination operand.
+    bss = Byte, sign-extended to the size of the stack pointer (for example, PUSH (6A)).
+    w  =  WORD .
+    d  =  DWORD .
+    q  =  QUADWORD .
+    v  =  Word or Dword or Quadword (64 bit).
+    p  =  32-bit or 48-bit pointer, depending on operand-size attribute (for example, CALLF (9A).
+    dr =  Double-real. Only x87 FPU instructions (for example, FADD).
+    di =  DoubleWord-integer. Only x87 FPU instructions (for example, FIADD).
+    wi =  Word-integer. Only x87 FPU instructions (for example, FIADD).
+    ps =  128-bit packed single-precision floating-point data.
+    psq =  64-bit packed single-precision floating-point data.
+
+  }
+
+  Op_NONE = 0; // Operand is not used.
+
+  Op_b = $1;
+  Op_w = $2;
+  Op_d = $4;
+  Op_q = $8;
+  Op_v = Op_w or Op_d;
+  Op_vqp = Op_v or Op_q;
+  Op_SignExt = $10;
+  Op_bs = Op_b or Op_SignExt;
+  Op_Stack = $20;
+
+  { One Byte Reg }
+  Op_Regb = $1;
+  Op_AH = Op_Regb;
+  Op_AL = Op_Regb;
+  Op_CL = Op_Regb;
+
+  { 2 Bytes Reg }
+  Op_Regw = $2;
+  Op_AX = Op_Regw;
+  Op_CX = Op_Regw;
+  Op_DX = Op_Regw;
+  Op_DI = Op_Regw;
+
+  { DWORD Reg }
+  Op_Regd = $4;
+  Op_eAX = Op_Regd;
+  Op_eCX = Op_Regd;
+  Op_eBP = Op_Regd;
+  Op_EBX = Op_Regd;
+
+  { x64 Reg }
+  Op_Regq = $8;
+  Op_rAX = Op_Regq;
+  Op_rCX = Op_Regq;
+
+  { EFLAGS Reg }
+  Op_Regf = $2;
+  Op_Regef = $4;
+  Op_Flags = Op_Regf; // 2 Bytes reg .
+  Op_eFlags = Op_Regef; // 4 Bytes reg .
+
+  { Segment Registers }
+  Op_Segr = $40;
+  Op_SS = Op_Segr; // stack segment .
+  Op_ES = Op_Segr; // extra segment .
+  Op_CS = Op_Segr; // code segment .
+  Op_DS = Op_Segr; // data segment .
+  Op_FS = Op_Segr;
+  Op_GS = Op_Segr;
+
+  Op_Sw = $80 or Op_w; // ModRM select Segment Registers + Word .e.g : MOV WORD PTR SS:[EBP+55],DS .
+  Op_ESsr = $80; // ModR/M byte selects a segment register
+  Op_SS_rSP = $80; // SS:[rSP]
+  Op_ES_DI = $80; // ES:[DI]
+  Op_DS_SI = $80; // DS:[SI]
+  Op_DS_rSI = $80; // (DS):[rSI]
+  Op_ES_rDI = $80; // (ES:)[rDI]
+  Op_DS_rBX_AL = $80; // (DS:)[rBX+AL]
+  Op_DS_rDI = $80;
+
+  Op_E = $100;
+  Op_G = $200; // general-purpose register .
+  Op_Eb = Op_E or Op_b; // general-purpose register (AL,BL,..) or memory address .
+  Op_Ew = Op_E or Op_w; // general-purpose register (AX,BX,..) or memory address .
+  Op_Ed = Op_E or Op_d;
+  Op_Ev = Op_E or Op_v; // eneral-purpose register (EAX,AX,..) or memory address .
+  Op_Evqp = Op_E or Op_vqp; // eneral-purpose register (RAX,EAX,AX,..) or memory address .
+  Op_Gb = Op_G or Op_b; // eneral-purpose register (AL,BL,..).
+  Op_Gw = Op_G or Op_w; // general-purpose register (AX,BX,..).
+  Op_Gd = Op_G or Op_d;
+  Op_Gv = Op_G or Op_v; // general-purpose register Word or Dword (EAX,EBX,AX,BX,..).
+  Op_Gvqp = Op_G or Op_vqp; // eneral-purpose register (RAX,EAX,AX,..).
+  Op_Z = $400; // no ModR/M ; Registers are used .
+  Op_Zb = Op_Z or Op_b; // no ModR/M ; Registers are used => Byte Reg (AL,BL,..)
+  Op_Zv = Op_Z or Op_b;
+  Op_Zvqp = Op_Z or Op_vqp;
+
+  { Immediate }
+  Op_Imm = $800;
+  Op_Ib = Op_Imm or Op_b; // size of immediate = Byte .
+  Op_Ibs = Op_Ib or Op_bs; // Byte, sign-extended to the size of the destination operand.
+  Op_Ibss = Op_Ibs or Op_Stack; // Byte, sign-extended to the size of the stack pointer (for example, PUSH (6A)). eg: PUSH -5 .
+  Op_Iw = Op_Imm or Op_w; // size of immediate = Word .
+  Op_Ivs = Op_Imm or Op_v or Op_SignExt; // Word or doubleword sign extended to the size of the stack pointer (for example, PUSH (68)).
+  Op_Ivqp = Op_Imm or Op_vqp; // Word or doubleword, depending on operand-size attribute, or quadword, promoted by REX.W in 64-bit mode.
+  Op_Ivds = Op_Imm or Op_v or Op_SignExt;
+
+  Op_Ap = $1000; // Direct address ; No ModRM .
+
+  Op_M = $2000; // The ModR/M byte may refer only to memory.
+  Op_Ma = Op_M or 1; // Two one-word operands in memory or two double-word operands in memory  .
+  Op_Mdr = Op_M or 2; // Mem=Double-real.
+  Op_Mwi = Op_M or 4; // Mem=Word-integer.
+  Op_Mp = Op_M or 8; // Mem=32-bit or 48-bit pointer.
+  Op_Mdi = Op_M or $10; // Mem=DWORD-integer.
+  Op_Mw = Op_M or $20; // Mem=Word Memory . e.g : MOV EAX,WORD PRT DS:[EBX].
+  Op_Msr = Op_M or $40; // Mem = Segment Registers .
+
+  op_vds = Op_v or $4000;
+  Op_J = $8000;
+  Op_Jbs = Op_J or Op_bs; // relative offset;sign-extended .e.g : JO -5 .
+
+  Op_O = $10000;
+  Op_Ob = Op_O or Op_b;
+  Op_Ovqp = Op_O or Op_vqp;
+  Op_Jvds = Op_J or op_vds;
+
+  Op_1 = $20000;
+  Op_3 = $40000;
+  Op_ST = $80000;
+  Op_TwoByte = $100000;
+
+  Op_XMM = $200000;
+  Op_U = Op_XMM;
+  Op_2V = Op_XMM;
+  Op_2W = Op_XMM or Op_E;
+  Op_p = $400000;
+  Op_ps = $800000;
+  Op_2D = Op_G;
+  Op_2ss = $1000000; // Scalar element of a 128-bit packed single-precision floating data.
+  Op_psq = Op_ps or Op_q;
+  Op_LDTR = 0;
+  Op_GDTR = 0;
+  Op_Ms = 0;
+  Op_Mq = Op_M or Op_q;
+  Op_Uq = Op_U or Op_q;
+  Op_CR0 = 0;
+  Op_Vps = Op_2V or Op_ps;
+  Op_Wq = Op_2W or Op_q;
+  Op_Wps = Op_2W or Op_ps;
+  Op_Vq = Op_2V or Op_q;
+  Op_Dd = Op_2D or Op_d;
+  Op_Td = 0;
+  Op_Rd = Op_G or Op_d;
+  Op_Cd = 0;
+  Op_Qpi = 0;
+  Op_Mps = Op_M or Op_ps;
+  Op_Ppi = 0;
+  Op_Wpsq = Op_2W or Op_psq;
+  Op_Vss = Op_2V or Op_2ss;
+  Op_Wss = Op_2W or Op_2ss;
+  Op_PMC = 0;
+  Op_Nq = 0;
+  Op_Pq = 0;
+  Op_Qd = 0;
+  Op_Qq = 0;
+  Op_Gdqp = 0;
+  Op_Ups = Op_U or Op_ps;
+  Op_Vpd = Op_2V or Op_p or Op_d;
+  Op_Wdq = Op_2W or Op_d or Op_q;
+  Op_Mdq = Op_M or Op_d or Op_q;
+  Op_Vdq = Op_2V or Op_d or Op_q;
+  Op_Wpd = Op_2W or Op_p or Op_d;
+  Op_Mstx = 0;
+  Op_ST1 = 0;
+  Op_Mptp = 0;
+  Op_Mdqp = 0;
+  Op_Rdqp = 0;
+  Op_IA32_BIOS_SIGN_ID = 0;
+  Op_IA32_SYSENTER_CS = 0;
+  Op_IA32_SYSENTER_ESP = 0;
+  Op_IA32_TIME_STAMP_COUNTER = 0;
+
+type
+  TOpCodeEntryInfo = packed record
+    Flags: Byte;
+    Op1: DWORD;
+    Op2: DWORD;
+    Op3: DWORD;
+    Op4: DWORD;
+  end;
+
+const
+  { 50-58;58-59;59-60;90-98;B80-B8;B8-C0 }
+  OneByteOpCodesEntry: array [0 .. $FF] of TOpCodeEntryInfo = (
+    { 00 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 01 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 02 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gb; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 03 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 04 } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 05 } (Flags: Opf_W; Op1: Op_rAX; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 06 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_ES; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 07 } (Flags: Opf_NONE; Op1: Op_ES; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 08 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { OR } ,
+    { 09 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { OR } ,
+    { 0A } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gb; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { OR } ,
+    { 0B } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { OR } ,
+    { 0C } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { OR } ,
+    { 0D } (Flags: Opf_W; Op1: Op_rAX; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { OR } ,
+    { 0E } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_CS; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 0F } (Flags: Opf_NONE; Op1: Op_CS; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 10 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { ADC } ,
+    { 11 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { ADC } ,
+    { 12 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gb; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { ADC } ,
+    { 13 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { ADC } ,
+    { 14 } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { ADC } ,
+    { 15 } (Flags: Opf_W; Op1: Op_rAX; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { ADC } ,
+    { 16 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_SS; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 17 } (Flags: Opf_NONE; Op1: Op_SS; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 18 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { SBB } ,
+    { 19 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { SBB } ,
+    { 1A } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gb; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { SBB } ,
+    { 1B } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { SBB } ,
+    { 1C } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { SBB } ,
+    { 1D } (Flags: Opf_W; Op1: Op_rAX; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { SBB } ,
+    { 1E } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_DS; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 1F } (Flags: Opf_NONE; Op1: Op_DS; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 20 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { AND } ,
+    { 21 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { AND } ,
+    { 22 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gb; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { AND } ,
+    { 23 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { AND } ,
+    { 24 } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { AND } ,
+    { 25 } (Flags: Opf_W; Op1: Op_rAX; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { AND } ,
+    { 26 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_ES; Op3: Op_NONE; Op4: Op_NONE) { ES } ,
+    { 27 } (Flags: Opf_NONE; Op1: Op_AL; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { DAA } ,
+    { 28 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { SUB } ,
+    { 29 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { SUB } ,
+    { 2A } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gb; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { SUB } ,
+    { 2B } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { SUB } ,
+    { 2C } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { SUB } ,
+    { 2D } (Flags: Opf_W; Op1: Op_rAX; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { SUB } ,
+    { 2E } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_CS; Op3: Op_NONE; Op4: Op_NONE) { CS } ,
+    { 2F } (Flags: Opf_NONE; Op1: Op_AL; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { DAS } ,
+    { 30 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { XOR } ,
+    { 31 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { XOR } ,
+    { 32 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gb; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { XOR } ,
+    { 33 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { XOR } ,
+    { 34 } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { XOR } ,
+    { 35 } (Flags: Opf_W; Op1: Op_rAX; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { XOR } ,
+    { 36 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_SS; Op3: Op_NONE; Op4: Op_NONE) { SS } ,
+    { 37 } (Flags: Opf_NONE; Op1: Op_AL; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { AAA } ,
+    { 38 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_NONE; Op2: Op_Eb; Op3: Op_Gb; Op4: Op_NONE) { CMP } ,
+    { 39 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_NONE; Op2: Op_Evqp; Op3: Op_Gvqp; Op4: Op_NONE) { CMP } ,
+    { 3A } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_NONE; Op2: Op_Gb; Op3: Op_Eb; Op4: Op_NONE) { CMP } ,
+    { 3B } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_NONE; Op2: Op_Gvqp; Op3: Op_Evqp; Op4: Op_NONE) { CMP } ,
+    { 3C } (Flags: Opf_W; Op1: Op_NONE; Op2: Op_AL; Op3: Op_Ib; Op4: Op_NONE) { CMP } ,
+    { 3D } (Flags: Opf_W; Op1: Op_NONE; Op2: Op_rAX; Op3: Op_Ivds; Op4: Op_NONE) { CMP } ,
+    { 3E } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_DS; Op3: Op_NONE; Op4: Op_NONE) { DS } ,
+    { 3F } (Flags: Opf_NONE; Op1: Op_AL; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { AAS } ,
+    { 40 } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { INC } ,
+    { 41 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.B } ,
+    { 42 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.X } ,
+    { 43 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.XB } ,
+    { 44 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.R } ,
+    { 45 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.RB } ,
+    { 46 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.RX } ,
+    { 47 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.RXB } ,
+    { 48 } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { DEC } ,
+    { 49 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.WB } ,
+    { 4A } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.WX } ,
+    { 4B } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.WXB } ,
+    { 4C } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.WR } ,
+    { 4D } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.WRB } ,
+    { 4E } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.WRX } ,
+    { 4F } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REX.WRXB } ,
+    { 50 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Zv; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 51 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Zv; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 52 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Zv; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 53 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Zv; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 54 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Zv; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 55 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Zv; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 56 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Zv; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 57 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Zv; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 58 } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 59 } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 5A } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 5B } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 5C } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 5D } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 5E } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 5F } (Flags: Opf_NONE; Op1: Op_Zv; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 60 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_AX; Op3: Op_CX; Op4: Op_NONE) { PUSHA } ,
+    { 61 } (Flags: Opf_NONE; Op1: Op_DI; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POPA } ,
+    { 62 } (Flags: Opf_D or Opf_ModRM; Op1: Op_SS_rSP; Op2: Op_Gv; Op3: Op_Ma; Op4: Op_NONE) { BOUND } ,
+    { 63 } (Flags: Opf_ModRM; Op1: Op_NONE; Op2: Op_Ew; Op3: Op_Gw; Op4: Op_NONE) { ARPL } ,
+    { 64 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_FS; Op3: Op_NONE; Op4: Op_NONE) { FS } ,
+    { 65 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_GS; Op3: Op_NONE; Op4: Op_NONE) { GS } ,
+    { 66 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { } ,
+    { 67 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { } ,
+    { 68 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Ivs; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 69 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_Ivds; Op4: Op_NONE) { IMUL } ,
+    { 6A } (Flags: Opf_S; Op1: Op_SS_rSP; Op2: Op_Ibss; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { 6B } (Flags: Opf_ModRM or Opf_S; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_Ibs; Op4: Op_NONE) { IMUL } ,
+    { 6C } (Flags: Opf_W; Op1: Op_ES_rDI; Op2: Op_DX; Op3: Op_NONE; Op4: Op_NONE) { INS } ,
+    { 6D } (Flags: Opf_W; Op1: Op_ES_DI; Op2: Op_DX; Op3: Op_NONE; Op4: Op_NONE) { INS } ,
+    { 6E } (Flags: Opf_W; Op1: Op_DX; Op2: Op_DS_rSI; Op3: Op_NONE; Op4: Op_NONE) { OUTS } ,
+    { 6F } (Flags: Opf_W; Op1: Op_DX; Op2: Op_DS_SI; Op3: Op_NONE; Op4: Op_NONE) { OUTS } ,
+    { 70 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JO } ,
+    { 71 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JNO } ,
+    { 72 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JB } ,
+    { 73 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JNB } ,
+    { 74 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JZ } ,
+    { 75 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JNZ } ,
+    { 76 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JBE } ,
+    { 77 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JNBE } ,
+    { 78 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JS } ,
+    { 79 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JNS } ,
+    { 7A } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JP } ,
+    { 7B } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JNP } ,
+    { 7C } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JL } ,
+    { 7D } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JNL } ,
+    { 7E } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JLE } ,
+    { 7F } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JNLE } ,
+    { 80 } (Flags: Opf_W or Opf_L or Opf_ModRMExt; Op1: Op_Eb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 81 } (Flags: Opf_W or Opf_L or Opf_ModRMExt; Op1: Op_Evqp; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 82 } (Flags: Opf_W or Opf_L or Opf_ModRMExt; Op1: Op_Eb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 83 } (Flags: Opf_W or Opf_L or Opf_S or Opf_ModRMExt; Op1: Op_Evqp; Op2: Op_Ibs; Op3: Op_NONE; Op4: Op_NONE) { ADD } ,
+    { 84 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_NONE; Op2: Op_Eb; Op3: Op_Gb; Op4: Op_NONE) { TEST } ,
+    { 85 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_NONE; Op2: Op_Evqp; Op3: Op_Gvqp; Op4: Op_NONE) { TEST } ,
+    { 86 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Gb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 87 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Gvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 88 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 89 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 8A } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gb; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 8B } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 8C } (Flags: Opf_D or Opf_ModRM; Op1: Op_Mw; Op2: Op_Sw; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 8D } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_M; Op3: Op_NONE; Op4: Op_NONE) { LEA } ,
+    { 8E } (Flags: Opf_D or Opf_ModRM; Op1: Op_Sw; Op2: Op_Ew; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 8F } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Ev; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { 90 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 91 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 92 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 93 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 94 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 95 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 96 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 97 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XCHG } ,
+    { 98 } (Flags: Opf_NONE; Op1: Op_AX; Op2: Op_AL; Op3: Op_NONE; Op4: Op_NONE) { CBW } ,
+    { 99 } (Flags: Opf_NONE; Op1: Op_DX; Op2: Op_AX; Op3: Op_NONE; Op4: Op_NONE) { CWD } ,
+    { 9A } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Ap; Op3: Op_NONE; Op4: Op_NONE) { CALLF } ,
+    { 9B } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { FWAIT } ,
+    { 9C } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Flags; Op3: Op_NONE; Op4: Op_NONE) { PUSHF } ,
+    { 9D } (Flags: Opf_NONE; Op1: Op_Flags; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POPF } ,
+    { 9E } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_AH; Op3: Op_NONE; Op4: Op_NONE) { SAHF } ,
+    { 9F } (Flags: Opf_NONE; Op1: Op_AH; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { LAHF } ,
+    { A0 } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ob; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { A1 } (Flags: Opf_W; Op1: Op_rAX; Op2: Op_Ovqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { A2 } (Flags: Opf_W; Op1: Op_Ob; Op2: Op_AL; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { A3 } (Flags: Opf_W; Op1: Op_Ovqp; Op2: Op_rAX; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { A4 } (Flags: Opf_W; Op1: Op_ES_rDI; Op2: Op_DS_rSI; Op3: Op_NONE; Op4: Op_NONE) { MOVS } ,
+    { A5 } (Flags: Opf_W; Op1: Op_ES_DI; Op2: Op_DS_SI; Op3: Op_NONE; Op4: Op_NONE) { MOVS } ,
+    { A6 } (Flags: Opf_W; Op1: Op_NONE; Op2: Op_ES_rDI; Op3: Op_NONE; Op4: Op_NONE) { CMPS } ,
+    { A7 } (Flags: Opf_W; Op1: Op_NONE; Op2: Op_ES_DI; Op3: Op_NONE; Op4: Op_NONE) { CMPS } ,
+    { A8 } (Flags: Opf_W; Op1: Op_NONE; Op2: Op_AL; Op3: Op_Ib; Op4: Op_NONE) { TEST } ,
+    { A9 } (Flags: Opf_W; Op1: Op_NONE; Op2: Op_rAX; Op3: Op_Ivds; Op4: Op_NONE) { TEST } ,
+    { AA } (Flags: Opf_W; Op1: Op_ES_rDI; Op2: Op_AL; Op3: Op_NONE; Op4: Op_NONE) { STOS } ,
+    { AB } (Flags: Opf_W; Op1: Op_ES_DI; Op2: Op_AX; Op3: Op_NONE; Op4: Op_NONE) { STOS } ,
+    { AC } (Flags: Opf_W; Op1: Op_AL; Op2: Op_DS_rSI; Op3: Op_NONE; Op4: Op_NONE) { LODS } ,
+    { AD } (Flags: Opf_W; Op1: Op_AX; Op2: Op_DS_SI; Op3: Op_NONE; Op4: Op_NONE) { LODS } ,
+    { AE } (Flags: Opf_W; Op1: Op_NONE; Op2: Op_ES_rDI; Op3: Op_AL; Op4: Op_NONE) { SCAS } ,
+    { AF } (Flags: Opf_W; Op1: Op_NONE; Op2: Op_ES_DI; Op3: Op_NONE; Op4: Op_NONE) { SCAS } ,
+    { B0 } (Flags: Opf_NONE; Op1: Op_Zb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B1 } (Flags: Opf_NONE; Op1: Op_Zb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B2 } (Flags: Opf_NONE; Op1: Op_Zb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B3 } (Flags: Opf_NONE; Op1: Op_Zb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B4 } (Flags: Opf_NONE; Op1: Op_Zb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B5 } (Flags: Opf_NONE; Op1: Op_Zb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B6 } (Flags: Opf_NONE; Op1: Op_Zb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B7 } (Flags: Opf_NONE; Op1: Op_Zb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B8 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_Ivqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { B9 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_Ivqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { BA } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_Ivqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { BB } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_Ivqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { BC } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_Ivqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { BD } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_Ivqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { BE } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_Ivqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { BF } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_Ivqp; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { C0 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Eb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { ROL } ,
+    { C1 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Evqp; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { ROL } ,
+    { C2 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { RETN } ,
+    { C3 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { RETN } ,
+    { C4 } (Flags: Opf_ModRM; Op1: Op_ES; Op2: Op_Mp; Op3: Op_NONE; Op4: Op_NONE) { LES } ,
+    { C5 } (Flags: Opf_ModRM; Op1: Op_DS; Op2: Op_Mp; Op3: Op_NONE; Op4: Op_NONE) { LDS } ,
+    { C6 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Eb; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { C7 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Evqp; Op2: Op_Ivds; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { C8 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Iw; Op3: Op_Ib; Op4: Op_NONE) { ENTER } ,
+    { C9 } (Flags: Opf_NONE; Op1: Op_eBP; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { LEAVE } ,
+    { CA } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Iw; Op3: Op_SS_rSP; Op4: Op_NONE) { RETF } ,
+    { CB } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { RETF } ,
+    { CC } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_3; Op3: Op_eFlags; Op4: Op_NONE) { INT } ,
+    { CD } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_Ib; Op3: Op_eFlags; Op4: Op_NONE) { INT } ,
+    { CE } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_eFlags; Op3: Op_NONE; Op4: Op_NONE) { INTO } ,
+    { CF } (Flags: Opf_NONE; Op1: Op_Flags; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { IRET } ,
+    { D0 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Eb; Op2: Op_1; Op3: Op_NONE; Op4: Op_NONE) { ROL } ,
+    { D1 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Evqp; Op2: Op_1; Op3: Op_NONE; Op4: Op_NONE) { ROL } ,
+    { D2 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Eb; Op2: Op_CL; Op3: Op_NONE; Op4: Op_NONE) { ROL } ,
+    { D3 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Evqp; Op2: Op_CL; Op3: Op_NONE; Op4: Op_NONE) { ROL } ,
+    { D4 } (Flags: Opf_NONE; Op1: Op_AL; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { AAM } ,
+    { D5 } (Flags: Opf_NONE; Op1: Op_AL; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { AAD } ,
+    { D6 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { } ,
+    { D7 } (Flags: Opf_NONE; Op1: Op_AL; Op2: Op_DS_rBX_AL; Op3: Op_NONE; Op4: Op_NONE) { XLAT } ,
+    { D8 } (Flags: Opf_ModRMExt; Op1: Op_ST; Op2: Op_Msr; Op3: Op_NONE; Op4: Op_NONE) { FADD } ,
+    { D9 } (Flags: Opf_ModRMExt; Op1: Op_ST; Op2: Op_ESsr; Op3: Op_NONE; Op4: Op_NONE) { FLD } ,
+    { DA } (Flags: Opf_ModRMExt; Op1: Op_ST; Op2: Op_Mdi; Op3: Op_NONE; Op4: Op_NONE) { FIADD } ,
+    { DB } (Flags: Opf_ModRMExt; Op1: Op_ST; Op2: Op_Mdi; Op3: Op_NONE; Op4: Op_NONE) { FILD } ,
+    { DC } (Flags: Opf_ModRMExt; Op1: Op_ST; Op2: Op_Mdr; Op3: Op_NONE; Op4: Op_NONE) { FADD } ,
+    { DD } (Flags: Opf_ModRMExt; Op1: Op_ST; Op2: Op_Mdr; Op3: Op_NONE; Op4: Op_NONE) { FLD } ,
+    { DE } (Flags: Opf_ModRMExt; Op1: Op_ST; Op2: Op_Mwi; Op3: Op_NONE; Op4: Op_NONE) { FIADD } ,
+    { DF } (Flags: Opf_ModRMExt; Op1: Op_ST; Op2: Op_Mwi; Op3: Op_NONE; Op4: Op_NONE) { FILD } ,
+    { E0 } (Flags: Opf_Jump; Op1: Op_eCX; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { LOOPNZ } ,
+    { E1 } (Flags: Opf_Jump; Op1: Op_eCX; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { LOOPZ } ,
+    { E2 } (Flags: Opf_Jump; Op1: Op_eCX; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { LOOP } ,
+    { E3 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_CX; Op4: Op_NONE) { JCXZ } ,
+    { E4 } (Flags: Opf_W; Op1: Op_AL; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { IN } ,
+    { E5 } (Flags: Opf_W; Op1: Op_eAX; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { IN } ,
+    { E6 } (Flags: Opf_W; Op1: Op_Ib; Op2: Op_AL; Op3: Op_NONE; Op4: Op_NONE) { OUT } ,
+    { E7 } (Flags: Opf_W; Op1: Op_Ib; Op2: Op_eAX; Op3: Op_NONE; Op4: Op_NONE) { OUT } ,
+    { E8 } (Flags: Opf_Jump; Op1: Op_SS_rSP; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { CALL } ,
+    { E9 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JMP } ,
+    { EA } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Ap; Op3: Op_NONE; Op4: Op_NONE) { JMPF } ,
+    { EB } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jbs; Op3: Op_NONE; Op4: Op_NONE) { JMP } ,
+    { EC } (Flags: Opf_W; Op1: Op_AL; Op2: Op_DX; Op3: Op_NONE; Op4: Op_NONE) { IN } ,
+    { ED } (Flags: Opf_W; Op1: Op_eAX; Op2: Op_DX; Op3: Op_NONE; Op4: Op_NONE) { IN } ,
+    { EE } (Flags: Opf_W; Op1: Op_DX; Op2: Op_AL; Op3: Op_NONE; Op4: Op_NONE) { OUT } ,
+    { EF } (Flags: Opf_W; Op1: Op_DX; Op2: Op_eAX; Op3: Op_NONE; Op4: Op_NONE) { OUT } ,
+    { F0 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { LOCK } ,
+    { F1 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { } ,
+    { F2 } (Flags: Opf_NONE; Op1: Op_eCX; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REPNZ } ,
+    { F3 } (Flags: Opf_NONE; Op1: Op_eCX; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { REPZ } ,
+    { F4 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { HLT } ,
+    { F5 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { CMC } ,
+    { F6 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_NONE; Op2: Op_Eb; Op3: Op_Ib; Op4: Op_NONE) { TEST } ,
+    { F7 } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_NONE; Op2: Op_Evqp; Op3: Op_Ivqp; Op4: Op_NONE) { TEST } ,
+    { F8 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { CLC } ,
+    { F9 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { STC } ,
+    { FA } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { CLI } ,
+    { FB } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { STI } ,
+    { FC } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { CLD } ,
+    { FD } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { STD } ,
+    { FE } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { INC } ,
+    { FF } (Flags: Opf_W or Opf_ModRMExt; Op1: Op_Evqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { INC }
+    );
+
+  { TwoByteOpCodesEntry }
+  TwoByteOpCodesEntry: array [0 .. $FF] of TOpCodeEntryInfo = (
+    { 00 } (Flags: Opf_ModRMExt; Op1: Op_Mw; Op2: Op_LDTR; Op3: Op_NONE; Op4: Op_NONE) { SLDT } ,
+    { 01 } (Flags: Opf_ModRMExt; Op1: Op_Ms; Op2: Op_GDTR; Op3: Op_NONE; Op4: Op_NONE) { SGDT } ,
+    { 02 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Mw; Op3: Op_NONE; Op4: Op_NONE) { LAR } ,
+    { 03 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Mw; Op3: Op_NONE; Op4: Op_NONE) { LSL } ,
+    { 04 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Mw; Op3: Op_NONE; Op4: Op_NONE) { LSL } ,
+    { 05 } (Flags: Opf_NONE; Op1: Op_AX; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { LOADALL } ,
+    { 06 } (Flags: Opf_NONE; Op1: Op_CR0; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { CLTS } ,
+    { 07 } (Flags: Opf_NONE; Op1: Op_eAX; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { LOADALL } ,
+    { 08 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { INVD } ,
+    { 09 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { WBINVD } ,
+    { 0A } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { WBINVD } ,
+    { 0B } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { UD2 } ,
+    { 0C } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { UD2 } ,
+    { 0D } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { NOP } ,
+    { 0E } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { NOP } ,
+    { 0F } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { NOP } ,
+    { 10 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { MOVUPS } ,
+    { 11 } (Flags: Opf_ModRM; Op1: Op_Wps; Op2: Op_Vps; Op3: Op_NONE; Op4: Op_NONE) { MOVUPS } ,
+    { 12 } (Flags: Opf_ModRM; Op1: Op_Vq; Op2: Op_Uq; Op3: Op_NONE; Op4: Op_NONE) { MOVHLPS } ,
+    { 13 } (Flags: Opf_ModRM; Op1: Op_Mq; Op2: Op_Vq; Op3: Op_NONE; Op4: Op_NONE) { MOVLPS } ,
+    { 14 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wq; Op3: Op_NONE; Op4: Op_NONE) { UNPCKLPS } ,
+    { 15 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wq; Op3: Op_NONE; Op4: Op_NONE) { UNPCKHPS } ,
+    { 16 } (Flags: Opf_ModRM; Op1: Op_Vq; Op2: Op_Uq; Op3: Op_NONE; Op4: Op_NONE) { MOVLHPS } ,
+    { 17 } (Flags: Opf_ModRM; Op1: Op_Mq; Op2: Op_Vq; Op3: Op_NONE; Op4: Op_NONE) { MOVHPS } ,
+    { 18 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { HINT_NOP } ,
+    { 19 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { HINT_NOP } ,
+    { 1A } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { HINT_NOP } ,
+    { 1B } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { HINT_NOP } ,
+    { 1C } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { HINT_NOP } ,
+    { 1D } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { HINT_NOP } ,
+    { 1E } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { HINT_NOP } ,
+    { 1F } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_Ev; Op3: Op_NONE; Op4: Op_NONE) { HINT_NOP } ,
+    { 20 } (Flags: Opf_ModRM; Op1: Op_Rd; Op2: Op_Cd; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 21 } (Flags: Opf_ModRM; Op1: Op_Rd; Op2: Op_Dd; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 22 } (Flags: Opf_ModRM; Op1: Op_Cd; Op2: Op_Rd; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 23 } (Flags: Opf_ModRM; Op1: Op_Dd; Op2: Op_Rd; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 24 } (Flags: Opf_ModRM; Op1: Op_Rd; Op2: Op_Td; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 25 } (Flags: Opf_ModRM; Op1: Op_Rd; Op2: Op_Td; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 26 } (Flags: Opf_ModRM; Op1: Op_Td; Op2: Op_Rd; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 27 } (Flags: Opf_ModRM; Op1: Op_Td; Op2: Op_Rd; Op3: Op_NONE; Op4: Op_NONE) { MOV } ,
+    { 28 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { MOVAPS } ,
+    { 29 } (Flags: Opf_ModRM; Op1: Op_Wps; Op2: Op_Vps; Op3: Op_NONE; Op4: Op_NONE) { MOVAPS } ,
+    { 2A } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Qpi; Op3: Op_NONE; Op4: Op_NONE) { CVTPI2PS } ,
+    { 2B } (Flags: Opf_ModRM; Op1: Op_Mps; Op2: Op_Vps; Op3: Op_NONE; Op4: Op_NONE) { MOVNTPS } ,
+    { 2C } (Flags: Opf_ModRM; Op1: Op_Ppi; Op2: Op_Wpsq; Op3: Op_NONE; Op4: Op_NONE) { CVTTPS2PI } ,
+    { 2D } (Flags: Opf_ModRM; Op1: Op_Ppi; Op2: Op_Wpsq; Op3: Op_NONE; Op4: Op_NONE) { CVTPS2PI } ,
+    { 2E } (Flags: Opf_ModRM; Op1: Op_NONE; Op2: Op_Vss; Op3: Op_Wss; Op4: Op_NONE) { UCOMISS } ,
+    { 2F } (Flags: Opf_ModRM; Op1: Op_NONE; Op2: Op_Vss; Op3: Op_Wss; Op4: Op_NONE) { COMISS } ,
+    { 30 } (Flags: Opf_NONE; Op1: Op_Msr; Op2: Op_rCX; Op3: Op_rAX; Op4: Op_NONE) { WRMSR } ,
+    { 31 } (Flags: Opf_NONE; Op1: Op_eAX; Op2: Op_IA32_TIME_STAMP_COUNTER; Op3: Op_NONE; Op4: Op_NONE) { RDTSC } ,
+    { 32 } (Flags: Opf_NONE; Op1: Op_rAX; Op2: Op_rCX; Op3: Op_Msr; Op4: Op_NONE) { RDMSR } ,
+    { 33 } (Flags: Opf_NONE; Op1: Op_eAX; Op2: Op_PMC; Op3: Op_NONE; Op4: Op_NONE) { RDPMC } ,
+    { 34 } (Flags: Opf_NONE; Op1: Op_SS; Op2: Op_IA32_SYSENTER_CS; Op3: Op_IA32_SYSENTER_ESP; Op4: Op_NONE) { SYSENTER } ,
+    { 35 } (Flags: Opf_NONE; Op1: Op_SS; Op2: Op_IA32_SYSENTER_CS; Op3: Op_rCX; Op4: Op_NONE) { SYSEXIT } ,
+    { 36 } (Flags: Opf_NONE; Op1: Op_SS; Op2: Op_IA32_SYSENTER_CS; Op3: Op_rCX; Op4: Op_NONE) { SYSEXIT } ,
+    { 37 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_eAX; Op3: Op_NONE; Op4: Op_NONE) { GETSEC } ,
+    { 38 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSHUFB } ,
+    { 39 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSHUFB } ,
+    { 3A } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_Ib; Op4: Op_NONE) { ROUNDPS } ,
+    { 3B } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_Ib; Op4: Op_NONE) { ROUNDPS } ,
+    { 3C } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_Ib; Op4: Op_NONE) { ROUNDPS } ,
+    { 3D } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_Ib; Op4: Op_NONE) { ROUNDPS } ,
+    { 3E } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_Ib; Op4: Op_NONE) { ROUNDPS } ,
+    { 3F } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_Ib; Op4: Op_NONE) { ROUNDPS } ,
+    { 40 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVO } ,
+    { 41 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVNO } ,
+    { 42 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVB } ,
+    { 43 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVNB } ,
+    { 44 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVZ } ,
+    { 45 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVNZ } ,
+    { 46 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVBE } ,
+    { 47 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVNBE } ,
+    { 48 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVS } ,
+    { 49 } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVNS } ,
+    { 4A } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVP } ,
+    { 4B } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVNP } ,
+    { 4C } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVL } ,
+    { 4D } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVNL } ,
+    { 4E } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVLE } ,
+    { 4F } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { CMOVNLE } ,
+    { 50 } (Flags: Opf_ModRM; Op1: Op_Gdqp; Op2: Op_Ups; Op3: Op_NONE; Op4: Op_NONE) { MOVMSKPS } ,
+    { 51 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { SQRTPS } ,
+    { 52 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { RSQRTPS } ,
+    { 53 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { RCPPS } ,
+    { 54 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { ANDPS } ,
+    { 55 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { ANDNPS } ,
+    { 56 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { ORPS } ,
+    { 57 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { XORPS } ,
+    { 58 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { ADDPS } ,
+    { 59 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { MULPS } ,
+    { 5A } (Flags: Opf_ModRM; Op1: Op_Vpd; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { CVTPS2PD } ,
+    { 5B } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wdq; Op3: Op_NONE; Op4: Op_NONE) { CVTDQ2PS } ,
+    { 5C } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { SUBPS } ,
+    { 5D } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { MINPS } ,
+    { 5E } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { DIVPS } ,
+    { 5F } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_NONE; Op4: Op_NONE) { MAXPS } ,
+    { 60 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PUNPCKLBW } ,
+    { 61 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PUNPCKLWD } ,
+    { 62 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PUNPCKLDQ } ,
+    { 63 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PACKSSWB } ,
+    { 64 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PCMPGTB } ,
+    { 65 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PCMPGTW } ,
+    { 66 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PCMPGTD } ,
+    { 67 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PACKUSWB } ,
+    { 68 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PUNPCKHBW } ,
+    { 69 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PUNPCKHWD } ,
+    { 6A } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PUNPCKHDQ } ,
+    { 6B } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PACKSSDW } ,
+    { 6C } (Flags: Opf_ModRM; Op1: Op_Vdq; Op2: Op_Wdq; Op3: Op_NONE; Op4: Op_NONE) { PUNPCKLQDQ } ,
+    { 6D } (Flags: Opf_ModRM; Op1: Op_Vdq; Op2: Op_Wdq; Op3: Op_NONE; Op4: Op_NONE) { PUNPCKHQDQ } ,
+    { 6E } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Ed; Op3: Op_NONE; Op4: Op_NONE) { MOVD } ,
+    { 6F } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { MOVQ } ,
+    { 70 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_Ib; Op4: Op_NONE) { PSHUFW } ,
+    { 71 } (Flags: Opf_ModRMExt; Op1: Op_Nq; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { PSRLW } ,
+    { 72 } (Flags: Opf_ModRMExt; Op1: Op_Nq; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { PSRLD } ,
+    { 73 } (Flags: Opf_ModRMExt; Op1: Op_Nq; Op2: Op_Ib; Op3: Op_NONE; Op4: Op_NONE) { PSRLQ } ,
+    { 74 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PCMPEQB } ,
+    { 75 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PCMPEQW } ,
+    { 76 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PCMPEQD } ,
+    { 77 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { EMMS } ,
+    { 78 } (Flags: Opf_ModRM; Op1: Op_Ed; Op2: Op_Gd; Op3: Op_NONE; Op4: Op_NONE) { VMREAD } ,
+    { 79 } (Flags: Opf_ModRM; Op1: Op_NONE; Op2: Op_Gd; Op3: Op_Ed; Op4: Op_NONE) { VMWRITE } ,
+    { 7A } (Flags: Opf_ModRM; Op1: Op_NONE; Op2: Op_Gd; Op3: Op_Ed; Op4: Op_NONE) { VMWRITE } ,
+    { 7B } (Flags: Opf_ModRM; Op1: Op_NONE; Op2: Op_Gd; Op3: Op_Ed; Op4: Op_NONE) { VMWRITE } ,
+    { 7C } (Flags: Opf_ModRM; Op1: Op_Vpd; Op2: Op_Wpd; Op3: Op_NONE; Op4: Op_NONE) { HADDPD } ,
+    { 7D } (Flags: Opf_ModRM; Op1: Op_Vpd; Op2: Op_Wpd; Op3: Op_NONE; Op4: Op_NONE) { HSUBPD } ,
+    { 7E } (Flags: Opf_ModRM; Op1: Op_Ed; Op2: Op_Pq; Op3: Op_NONE; Op4: Op_NONE) { MOVD } ,
+    { 7F } (Flags: Opf_ModRM; Op1: Op_Qq; Op2: Op_Pq; Op3: Op_NONE; Op4: Op_NONE) { MOVQ } ,
+    { 80 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JO } ,
+    { 81 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JNO } ,
+    { 82 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JB } ,
+    { 83 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JNB } ,
+    { 84 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JZ } ,
+    { 85 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JNZ } ,
+    { 86 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JBE } ,
+    { 87 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JNBE } ,
+    { 88 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JS } ,
+    { 89 } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JNS } ,
+    { 8A } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JP } ,
+    { 8B } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JNP } ,
+    { 8C } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JL } ,
+    { 8D } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JNL } ,
+    { 8E } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JLE } ,
+    { 8F } (Flags: Opf_Jump; Op1: Op_NONE; Op2: Op_Jvds; Op3: Op_NONE; Op4: Op_NONE) { JNLE } ,
+    { 90 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETO } ,
+    { 91 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETNO } ,
+    { 92 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETB } ,
+    { 93 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETNB } ,
+    { 94 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETZ } ,
+    { 95 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETNZ } ,
+    { 96 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETBE } ,
+    { 97 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETNBE } ,
+    { 98 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETS } ,
+    { 99 } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETNS } ,
+    { 9A } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETP } ,
+    { 9B } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETNP } ,
+    { 9C } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETL } ,
+    { 9D } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETNL } ,
+    { 9E } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETLE } ,
+    { 9F } (Flags: Opf_ModRMExt; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { SETNLE } ,
+    { A0 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_FS; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { A1 } (Flags: Opf_NONE; Op1: Op_FS; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { A2 } (Flags: Opf_NONE; Op1: Op_IA32_BIOS_SIGN_ID; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { CPUID } ,
+    { A3 } (Flags: Opf_ModRM; Op1: Op_NONE; Op2: Op_Evqp; Op3: Op_Gvqp; Op4: Op_NONE) { BT } ,
+    { A4 } (Flags: Opf_D or Opf_ModRM; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_Ib; Op4: Op_NONE) { SHLD } ,
+    { A5 } (Flags: Opf_D or Opf_ModRM; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_CL; Op4: Op_NONE) { SHLD } ,
+    { A6 } (Flags: Opf_D or Opf_ModRM; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_CL; Op4: Op_NONE) { SHLD } ,
+    { A7 } (Flags: Opf_D or Opf_ModRM; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_CL; Op4: Op_NONE) { SHLD } ,
+    { A8 } (Flags: Opf_NONE; Op1: Op_SS_rSP; Op2: Op_GS; Op3: Op_NONE; Op4: Op_NONE) { PUSH } ,
+    { A9 } (Flags: Opf_NONE; Op1: Op_GS; Op2: Op_SS_rSP; Op3: Op_NONE; Op4: Op_NONE) { POP } ,
+    { AA } (Flags: Opf_NONE; Op1: Op_Flags; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { RSM } ,
+    { AB } (Flags: Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { BTS } ,
+    { AC } (Flags: Opf_D or Opf_ModRM; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_Ib; Op4: Op_NONE) { SHRD } ,
+    { AD } (Flags: Opf_D or Opf_ModRM; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_CL; Op4: Op_NONE) { SHRD } ,
+    { AE } (Flags: Opf_ModRMExt; Op1: Op_Mstx; Op2: Op_ST; Op3: Op_ST1; Op4: Op_NONE) { FXSAVE } ,
+    { AF } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { IMUL } ,
+    { B0 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_Gb; Op3: Op_NONE; Op4: Op_NONE) { CMPXCHG } ,
+    { B1 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { CMPXCHG } ,
+    { B2 } (Flags: Opf_ModRM; Op1: Op_SS; Op2: Op_Mptp; Op3: Op_NONE; Op4: Op_NONE) { LSS } ,
+    { B3 } (Flags: Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { BTR } ,
+    { B4 } (Flags: Opf_ModRM; Op1: Op_FS; Op2: Op_Mptp; Op3: Op_NONE; Op4: Op_NONE) { LFS } ,
+    { B5 } (Flags: Opf_ModRM; Op1: Op_GS; Op2: Op_Mptp; Op3: Op_NONE; Op4: Op_NONE) { LGS } ,
+    { B6 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { MOVZX } ,
+    { B7 } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Ew; Op3: Op_NONE; Op4: Op_NONE) { MOVZX } ,
+    { B8 } (Flags: Opf_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { JMPE } ,
+    { B9 } (Flags: Opf_ModRM; Op1: Op_NONE; Op2: Op_G; Op3: Op_E; Op4: Op_NONE) { UD } ,
+    { BA } (Flags: Opf_ModRMExt; Op1: Op_NONE; Op2: Op_Evqp; Op3: Op_Ib; Op4: Op_NONE) { BT } ,
+    { BB } (Flags: Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_Gvqp; Op3: Op_NONE; Op4: Op_NONE) { BTC } ,
+    { BC } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { BSF } ,
+    { BD } (Flags: Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Evqp; Op3: Op_NONE; Op4: Op_NONE) { BSR } ,
+    { BE } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Eb; Op3: Op_NONE; Op4: Op_NONE) { MOVSX } ,
+    { BF } (Flags: Opf_D or Opf_W or Opf_ModRM; Op1: Op_Gvqp; Op2: Op_Ew; Op3: Op_NONE; Op4: Op_NONE) { MOVSX } ,
+    { C0 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Eb; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XADD } ,
+    { C1 } (Flags: Opf_D or Opf_W or Opf_ModRM or Opf_L; Op1: Op_Evqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { XADD } ,
+    { C2 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_Ib; Op4: Op_NONE) { CMPPS } ,
+    { C3 } (Flags: Opf_ModRM; Op1: Op_Mdqp; Op2: Op_Gdqp; Op3: Op_NONE; Op4: Op_NONE) { MOVNTI } ,
+    { C4 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Rdqp; Op3: Op_Ib; Op4: Op_NONE) { PINSRW } ,
+    { C5 } (Flags: Opf_ModRM; Op1: Op_Gdqp; Op2: Op_Nq; Op3: Op_Ib; Op4: Op_NONE) { PEXTRW } ,
+    { C6 } (Flags: Opf_ModRM; Op1: Op_Vps; Op2: Op_Wps; Op3: Op_Ib; Op4: Op_NONE) { SHUFPS } ,
+    { C7 } (Flags: Opf_L or Opf_ModRMExt; Op1: Op_Mq; Op2: Op_EBX; Op3: Op_eCX; Op4: Op_NONE) { CMPXCHG8B } ,
+    { C8 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { BSWAP } ,
+    { C9 } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { BSWAP } ,
+    { CA } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { BSWAP } ,
+    { CB } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { BSWAP } ,
+    { CC } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { BSWAP } ,
+    { CD } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { BSWAP } ,
+    { CE } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { BSWAP } ,
+    { CF } (Flags: Opf_NONE; Op1: Op_Zvqp; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { BSWAP } ,
+    { D0 } (Flags: Opf_ModRM; Op1: Op_Vpd; Op2: Op_Wpd; Op3: Op_NONE; Op4: Op_NONE) { ADDSUBPD } ,
+    { D1 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSRLW } ,
+    { D2 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSRLD } ,
+    { D3 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSRLQ } ,
+    { D4 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PADDQ } ,
+    { D5 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PMULLW } ,
+    { D6 } (Flags: Opf_ModRM; Op1: Op_Wq; Op2: Op_Vq; Op3: Op_NONE; Op4: Op_NONE) { MOVQ } ,
+    { D7 } (Flags: Opf_ModRM; Op1: Op_Gdqp; Op2: Op_Nq; Op3: Op_NONE; Op4: Op_NONE) { PMOVMSKB } ,
+    { D8 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSUBUSB } ,
+    { D9 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSUBUSW } ,
+    { DA } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PMINUB } ,
+    { DB } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PAND } ,
+    { DC } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PADDUSB } ,
+    { DD } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PADDUSW } ,
+    { DE } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PMAXUB } ,
+    { DF } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PANDN } ,
+    { E0 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PAVGB } ,
+    { E1 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSRAW } ,
+    { E2 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSRAD } ,
+    { E3 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PAVGW } ,
+    { E4 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PMULHUW } ,
+    { E5 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PMULHW } ,
+    { E6 } (Flags: Opf_ModRM; Op1: Op_Vdq; Op2: Op_Wpd; Op3: Op_NONE; Op4: Op_NONE) { CVTPD2DQ } ,
+    { E7 } (Flags: Opf_ModRM; Op1: Op_Mq; Op2: Op_Pq; Op3: Op_NONE; Op4: Op_NONE) { MOVNTQ } ,
+    { E8 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSUBSB } ,
+    { E9 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSUBSW } ,
+    { EA } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PMINSW } ,
+    { EB } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { POR } ,
+    { EC } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PADDSB } ,
+    { ED } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PADDSW } ,
+    { EE } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PMAXSW } ,
+    { EF } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PXOR } ,
+    { F0 } (Flags: Opf_ModRM; Op1: Op_Vdq; Op2: Op_Mdq; Op3: Op_NONE; Op4: Op_NONE) { LDDQU } ,
+    { F1 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSLLW } ,
+    { F2 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSLLD } ,
+    { F3 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSLLQ } ,
+    { F4 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PMULUDQ } ,
+    { F5 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qd; Op3: Op_NONE; Op4: Op_NONE) { PMADDWD } ,
+    { F6 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSADBW } ,
+    { F7 } (Flags: Opf_ModRM; Op1: Op_DS_rDI; Op2: Op_Nq; Op3: Op_NONE; Op4: Op_NONE) { MASKMOVQ } ,
+    { F8 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSUBB } ,
+    { F9 } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSUBW } ,
+    { FA } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSUBD } ,
+    { FB } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PSUBQ } ,
+    { FC } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PADDB } ,
+    { FD } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PADDW } ,
+    { FE } (Flags: Opf_ModRM; Op1: Op_Pq; Op2: Op_Qq; Op3: Op_NONE; Op4: Op_NONE) { PADDD } ,
+    { FF } (Flags: Op_NONE; Op1: Op_NONE; Op2: Op_NONE; Op3: Op_NONE; Op4: Op_NONE) { Invalid }
+    );

--- a/Source/DDetours/dDefs.inc
+++ b/Source/DDetours/dDefs.inc
@@ -1,0 +1,46 @@
+{$DEFINE UseInline}
+{$DEFINE BuildThreadSafe}
+{$DEFINE UseGenerics}
+//----------------------------------------------
+{$IFDEF FPC}
+  {$IFDEF CPU64}
+    {$IFNDEF CPUX64}
+      {$DEFINE CPUX64}
+    {$ENDIF !CPUX64}
+  {$ENDIF CPU64}
+{$ENDIF FPC}
+
+{$IFNDEF CPUX64}
+  {$IFNDEF CPUX86}
+    {$DEFINE CPUX86}
+  {$ENDIF !CPUX86}
+{$ENDIF !CPUX64}
+
+{$IFDEF DEBUG}
+{$R+} // Range check On
+{$ENDIF}
+
+{$IFNDEF FPC}
+  {$IF CompilerVersion >17}
+    {$DEFINE CanInline}
+  {$IFEND}
+  {$IF CompilerVersion >=20}
+    {$DEFINE GenericsExist }
+  {$IFEND}
+{$ENDIF !FPC}
+
+{$IF DEFINED(UseInline) and DEFINED(CanInline)}
+  {$DEFINE MustInline}
+{$IFEND}
+
+{$IF CompilerVersion >= 24} // 24 = XE3
+  {$DEFINE XE3ORGREATER}
+{$IFEND}
+
+// XE2: F2084 Internal Error: AV07A12278-W00000014-1
+// when DDetours.pas is compiled with this on.
+{$IF DEFINED(GenericsExist) and DEFINED(UseGenerics) and DEFINED(XE3ORGREATER)}
+  {$DEFINE MustUseGenerics}
+{$IFEND}
+
+

--- a/Source/EditorWizard/CnEditorJumpMessage.pas
+++ b/Source/EditorWizard/CnEditorJumpMessage.pas
@@ -269,7 +269,7 @@ begin
   if not CnMessageViewWrapper.MessageViewForm.Visible then
     CnMessageViewWrapper.MessageViewForm.Show;
 {$IFDEF BDS}
-  Hook := TCnMethodHook.Create(GetBplMethodAddress(@KeyDataToShiftState), @EmptyKeyDataToShiftState);
+  Hook := TCnMethodHook.Create(@KeyDataToShiftState, @EmptyKeyDataToShiftState);
   CnMessageViewWrapper.TreeView.Perform(WM_KEYDOWN, VK_DOWN, Integer($1500001));
   CnMessageViewWrapper.TreeView.Perform(WM_KEYUP, VK_DOWN, Integer($C1500001));
   Hook.Free;
@@ -306,7 +306,7 @@ begin
   if not CnMessageViewWrapper.MessageViewForm.Visible then
     CnMessageViewWrapper.MessageViewForm.Show;
 {$IFDEF BDS}
-  Hook := TCnMethodHook.Create(GetBplMethodAddress(@KeyDataToShiftState), @EmptyKeyDataToShiftState);
+  Hook := TCnMethodHook.Create(@KeyDataToShiftState, @EmptyKeyDataToShiftState);
   CnMessageViewWrapper.TreeView.Perform(WM_KEYDOWN, VK_UP, Integer($1500001));
   CnMessageViewWrapper.TreeView.Perform(WM_KEYUP, VK_UP, Integer($C1500001));
   Hook.Free;  

--- a/Source/Framework/CnWizOptions.pas
+++ b/Source/Framework/CnWizOptions.pas
@@ -524,7 +524,8 @@ end;
 
 procedure TCnWizOptions.SetUseOneCPUCore(const Value: Boolean);
 var
-  AMask, SysMask: TCnNativeUInt;
+  AMask,
+  SysMask: NativeUInt;
 begin
   FUseOneCPUCore := Value;
   if GetProcessAffinityMask(GetCurrentProcess, AMask, SysMask) then

--- a/Source/IdeEnhancements/CnInputHelper.pas
+++ b/Source/IdeEnhancements/CnInputHelper.pas
@@ -1845,8 +1845,7 @@ begin
     // IDE 在无法进行 CodeInsight 时会弹出一个错误框（不是异常）
     // 此处临时替换掉显示错误框的函数 MessageDlgPosHelp，使之不显示出来
     // 待调用完成后再恢复。
-    Hook := TCnMethodHook.Create(GetBplMethodAddress(@MessageDlgPosHelp),
-      @MyMessageDlgPosHelp);
+    Hook := TCnMethodHook.Create(@MessageDlgPosHelp, @MyMessageDlgPosHelp);
     try
       (EditView as IOTAEditActions).CodeCompletion(csCodeList or csManual);
     finally

--- a/Source/IdeEnhancements/CnInputIdeSymbolList.pas
+++ b/Source/IdeEnhancements/CnInputIdeSymbolList.pas
@@ -225,8 +225,7 @@ var
       // IDE 在无法进行 CodeInsight 时会弹出一个错误框（不是异常）
       // 此处临时替换掉显示错误框的函数 MessageDlgPosHelp，使之不显示出来
       // 待调用完成后再恢复。
-      Hook := TCnMethodHook.Create(GetBplMethodAddress(@MessageDlgPosHelp),
-        @MyMessageDlgPosHelp);
+      Hook := TCnMethodHook.Create(@MessageDlgPosHelp, @MyMessageDlgPosHelp);
       try
         Filter := '';
         Result := Manager.InvokeCodeCompletion(itManual, Filter);

--- a/Source/ProjectExtWizard/CnProjectExtWizard.pas
+++ b/Source/ProjectExtWizard/CnProjectExtWizard.pas
@@ -185,12 +185,8 @@ begin
     FOldViewDialogExecute := GetProcAddress(FCorIdeModule, SCnViewDialogExecuteName);
     if FOldViewDialogExecute <> nil then
     begin
-      FOldViewDialogExecute := GetBplMethodAddress(FOldViewDialogExecute);
-      if FOldViewDialogExecute <> nil then
-      begin
-        FMethodHook := TCnMethodHook.Create(FOldViewDialogExecute, @ShowProjectUseUnits);
-        FMethodHook.UnhookMethod;
-      end;
+      FMethodHook := TCnMethodHook.Create(FOldViewDialogExecute, @ShowProjectUseUnits);
+      FMethodHook.Disable;
     end;
   end;
 end;
@@ -662,12 +658,12 @@ begin
   begin
     // 不挂接，则需要取消 ViewDialogExecute 的挂接后跳回 IDE 原有的内容
     if FMethodHook <> nil then
-      FMethodHook.UnhookMethod;
+      FMethodHook.Disable;
     if Assigned(FOldUnitNotifyEvent) then
       FOldUnitNotifyEvent(Sender);
     // 如果以前挂了，再恢复
     if UseUnitsHookBtnChecked and (FMethodHook <> nil) then
-      FMethodHook.HookMethod;
+      FMethodHook.Enable;
   end;
 end;
 
@@ -679,12 +675,12 @@ begin
   begin
     // 不挂接，则需要取消 ViewDialogExecute 的挂接后跳回 IDE 原有的内容
     if FMethodHook <> nil then
-      FMethodHook.UnhookMethod;
+      FMethodHook.Disable;
     if Assigned(FOldFormNotifyEvent) then
       FOldFormNotifyEvent(Sender);
     // 如果以前挂了，再恢复
     if UseUnitsHookBtnChecked and (FMethodHook <> nil) then
-      FMethodHook.HookMethod;
+      FMethodHook.Enable;
   end;
 end;
 
@@ -725,9 +721,9 @@ begin
   if FMethodHook <> nil then
   begin
     if HookUseUnit then
-      FMethodHook.HookMethod
+      FMethodHook.Enable
     else
-      FMethodHook.UnhookMethod;
+      FMethodHook.Disable;
   end;
 end;
 

--- a/Source/SourceStat/CnStatWizard.pas
+++ b/Source/SourceStat/CnStatWizard.pas
@@ -196,9 +196,7 @@ begin
         OldFormReadError := GetProcAddress(ACorIdeModule, SCnFormReadErrorName);
         if OldFormReadError <> nil then
         begin
-          OldFormReadError := GetBplMethodAddress(OldFormReadError);
-          if OldFormReadError <> nil then
-            MethodHook := TCnMethodHook.Create(OldFormReadError, @HookedFormReadError);
+          MethodHook := TCnMethodHook.Create(OldFormReadError, @HookedFormReadError);
         end;
       end;
 

--- a/Source/SrcEditorEnhance/CnSrcEditorKey.pas
+++ b/Source/SrcEditorEnhance/CnSrcEditorKey.pas
@@ -167,6 +167,7 @@ uses
 
 type
   TControlHack = class(TControl);
+  TClickEventProc = procedure(Self : TObject; Sender : TObject); register;
 
 const
   csAutoIndentFile = 'AutoIndent.dat';
@@ -246,13 +247,7 @@ begin
   end;
 
   if FOldSrchDialogOKButtonClick <> nil then
-  begin
-    FMethodHook.UnhookMethod;
-    TMethod(ANotify).Code := FOldSrchDialogOKButtonClick;
-    TMethod(ANotify).Data := ASelf;
-    ANotify(Sender);
-    FMethodHook.HookMethod;
-  end;
+    TClickEventProc(FMethodHook.Trampoline)(ASelf, Sender);
 end;
 
 constructor TCnSrcEditorKey.Create;
@@ -268,11 +263,7 @@ begin
     FOldSrchDialogOKButtonClick := GetProcAddress(FCorIdeModule, SCnSrchDialogOKButtonClick);
     if FOldSrchDialogOKButtonClick <> nil then
     begin
-      FOldSrchDialogOKButtonClick := GetBplMethodAddress(FOldSrchDialogOKButtonClick);
-      if FOldSrchDialogOKButtonClick <> nil then
-      begin
-        FMethodHook := TCnMethodHook.Create(FOldSrchDialogOKButtonClick, @CnSrchDialogOKButtonClick);
-      end;
+      FMethodHook := TCnMethodHook.Create(FOldSrchDialogOKButtonClick, @CnSrchDialogOKButtonClick);
     end;
   end;
 

--- a/Source/Utils/CnWizIdeHooks.pas
+++ b/Source/Utils/CnWizIdeHooks.pas
@@ -104,8 +104,6 @@ begin
 end;
 
 procedure CnListBeginUpdate;
-var
-  Method: TListChangeMethod;
 begin
   if FUpdateCount = 0 then
   begin
@@ -117,12 +115,10 @@ begin
 
     FCnListComponent := TCnListComponent.Create(nil);
 
-    Method := TImageListAccess(GetIDEImageList).Change;
-    FImageListHook := TCnMethodHook.Create(GetBplMethodAddress(TMethod(Method).Code),
+    FImageListHook := TCnMethodHook.Create(@TImageListAccess.Change,
       @MyImageListChange);
-      
-    Method := TActionListAccess(GetIDEActionList).Change;
-    FActionListHook := TCnMethodHook.Create(GetBplMethodAddress(TMethod(Method).Code),
+
+    FActionListHook := TCnMethodHook.Create(@TActionListAccess.Change,
       @MyActionListChange);
   end;
   

--- a/Source/Utils/CnWizMethodHook.pas
+++ b/Source/Utils/CnWizMethodHook.pas
@@ -39,24 +39,21 @@ interface
 {$I CnWizards.inc}
 
 uses
-  Windows, SysUtils, Classes;
+  Windows, SysUtils, Classes, DDetours;
 
 type
-  PLongJump = ^TLongJump;
-  TLongJump = packed record
-    JmpOp: Byte;        // Jmp 相对跳转指令，为 $E9
-    Addr: Pointer;      // 跳转到的相对地址
-  end;
-
   TCnMethodHook = class
   {* 静态或 dynamic 方法挂接类，用于挂接类中静态方法或声明为 dynamic 的动态方法。
      该类通过修改原方法入口前 5字节，改为跳转指令来实现方法挂接操作，在使用时
      请保证原方法的执行体代码大于 5字节，否则可能会出现严重后果。}
   private
     FHooked: Boolean;
-    FOldMethod: Pointer;
-    FNewMethod: Pointer;
-    FSaveData: TLongJump;
+    FOldMethod,
+    FNewMethod,
+    FTrampoline : Pointer;
+  protected
+    procedure HookMethod; virtual;
+    procedure UnhookMethod; virtual;
   public
     constructor Create(const AOldMethod, ANewMethod: Pointer);
     {* 构造器，参数为原方法地址和新方法地址。注意如果在专家包中使用，原方法地址
@@ -69,41 +66,14 @@ type
      |</PRE>}
     destructor Destroy; override;
     {* 类析构器，取消挂接}
-    
-    procedure HookMethod; virtual;
-    {* 重新挂接，如果需要执行原过程，并使用了 UnhookMethod，请在执行完成后重新挂接}
-    procedure UnhookMethod; virtual;
-    {* 取消挂接，如果需要执行原过程，请先使用 UnhookMethod，再调用原过程，否则会出错}
-  end;
 
-function GetBplMethodAddress(Method: Pointer): Pointer;
-{* 返回在 BPL 中实际的方法地址。如专家包中用 @TPersistent.Assign 返回的其实是
-   一个 Jmp 跳转地址，该函数可以返回在 BPL 中方法的真实地址。}
+    procedure Enable;
+    procedure Disable;
+
+    property Trampoline : Pointer read FTrampoline;
+  end;
 
 implementation
-
-resourcestring
-  SMemoryWriteError = 'Error writing method memory (%s).';
-
-const
-  csJmpCode = $E9;              // 相对跳转指令机器码
-
-// 返回在 BPL 中实际的方法地址
-function GetBplMethodAddress(Method: Pointer): Pointer;
-type
-  PJmpCode = ^TJmpCode;
-  TJmpCode = packed record
-    Code: Word;                 // 间接跳转指定，为 $25FF
-    Addr: ^Pointer;             // 跳转指针地址，指向保存目标地址的指针
-  end;
-const
-  csJmp32Code = $25FF;
-begin
-  if PJmpCode(Method)^.Code = csJmp32Code then
-    Result := PJmpCode(Method)^.Addr^
-  else
-    Result := Method;
-end;
 
 //==============================================================================
 // 静态或 dynamic 方法挂接类
@@ -117,6 +87,7 @@ begin
   FHooked := False;
   FOldMethod := AOldMethod;
   FNewMethod := ANewMethod;
+  FTrampoline := nil;
   HookMethod;
 end;
 
@@ -126,59 +97,31 @@ begin
   inherited;
 end;
 
+procedure TCnMethodHook.Disable;
+begin
+  UnhookMethod;
+end;
+
+procedure TCnMethodHook.Enable;
+begin
+  HookMethod;
+end;
+
 procedure TCnMethodHook.HookMethod;
-var
-  DummyProtection: DWORD;
-  OldProtection: DWORD;
 begin
   if FHooked then Exit;
-  
-  // 设置代码页写访问权限
-  if not VirtualProtect(FOldMethod, SizeOf(TLongJump), PAGE_EXECUTE_READWRITE, @OldProtection) then
-    raise Exception.CreateFmt(SMemoryWriteError, [SysErrorMessage(GetLastError)]);
 
-  try
-    // 保存原来的代码
-    FSaveData := PLongJump(FOldMethod)^;
-
-    // 用跳转指令替换原来方法前 5 字节代码
-    PLongJump(FOldMethod)^.JmpOp := csJmpCode;
-    PLongJump(FOldMethod)^.Addr := Pointer(Integer(FNewMethod) -
-      Integer(FOldMethod) - SizeOf(TLongJump)); // 使用 32 位相对地址
-
-    // 保存多处理器下指令缓冲区同步
-    FlushInstructionCache(GetCurrentProcess, FOldMethod, SizeOf(TLongJump));
-  finally
-    // 恢复代码页访问权限
-    if not VirtualProtect(FOldMethod, SizeOf(TLongJump), OldProtection, @DummyProtection) then
-      raise Exception.CreateFmt(SMemoryWriteError, [SysErrorMessage(GetLastError)]);
-  end;
+  FTrampoline := DDetours.InterceptCreate(FOldMethod, FNewMethod);
 
   FHooked := True;
 end;
 
 procedure TCnMethodHook.UnhookMethod;
-var
-  DummyProtection: DWORD;
-  OldProtection: DWORD;
 begin
   if not FHooked then Exit;
-  
-  // 设置代码页写访问权限
-  if not VirtualProtect(FOldMethod, SizeOf(TLongJump), PAGE_READWRITE, @OldProtection) then
-    raise Exception.CreateFmt(SMemoryWriteError, [SysErrorMessage(GetLastError)]);
 
-  try
-    // 恢复原来的代码
-    PLongJump(FOldMethod)^ := FSaveData;
-  finally
-    // 恢复代码页访问权限
-    if not VirtualProtect(FOldMethod, SizeOf(TLongJump), OldProtection, @DummyProtection) then
-      raise Exception.CreateFmt(SMemoryWriteError, [SysErrorMessage(GetLastError)]);
-  end;
-
-  // 保存多处理器下指令缓冲区同步
-  FlushInstructionCache(GetCurrentProcess, FOldMethod, SizeOf(TLongJump));
+  DDetours.InterceptRemove(FTrampoline);
+  FTrampoline := nil;
 
   FHooked := False;
 end;


### PR DESCRIPTION
Changed TCnMethodHook to use DDetours. See issue https://github.com/cnpack/cnwizards/issues/2
- Most places it's used are completely replaced (procedures HookMethod and UnhookMethod are now protected, so can't be called externally.) Note CnProjectExtWizard still hooks and unhooks - not ideal, should probably change code structure to hook once and call trampoline (original method) when necessary.
- DDetours code is current as of today, with XE3 compiler tweak by me (generics in the .pas file can cause compiler errors, even if the generics are never used - the compiler seeing them is enough.)

IMPORTANT NOTES: DDetours is added here - you may want to add it another way, such as directly from its Google Code page: https://code.google.com/p/delphi-detours-library/wiki/DDetours

Please see issue #2. This fixes compatibility with other IDE wizards which two or more try to hook the same IDE methods, allowing CnPack to be installed with other wizards at the same time.
