### PR TITLE
Fixed error removing method hooks

### DIFF
--- a/Source/ThirdParty/DDetours/DDetours.pas
+++ b/Source/ThirdParty/DDetours/DDetours.pas
@@ -846,7 +846,7 @@ begin
     OrgProcAccess := SetMemPermission(P, Sb, PAGE_EXECUTE_READWRITE);
     CopyInstruction(Q^, P^, Sb);
     SetMemPermission(P, Sb, OrgProcAccess);
-    Result := VirtualFree(PSave, TrampolineSize, MEM_RELEASE);
+    Result := VirtualFree(PSave, 0, MEM_RELEASE);
 {$IFDEF BuildThreadSafe }
     if OpenThreadExist then
     begin

--- a/Source/Utils/CnWizMethodHook.pas
+++ b/Source/Utils/CnWizMethodHook.pas
@@ -155,6 +155,8 @@ var
 begin
 {$IFDEF USE_DDETOURS_HOOK}
   FTrampoline := DDetours.InterceptCreate(FOldMethod, FNewMethod);
+  if not Assigned(FTrampoline) then
+    raise Exception.Create('Failed to install method hook');
 {$ELSE}
   if FHooked then Exit;
   
@@ -190,7 +192,8 @@ var
 {$ENDIF}
 begin
 {$IFDEF USE_DDETOURS_HOOK}
-  DDetours.InterceptRemove(FTrampoline);
+  if not DDetours.InterceptRemove(FTrampoline) then
+    raise Exception.Create('Failed to release method hook');
   FTrampoline := nil;
 {$ELSE}
   if not FHooked then Exit;


### PR DESCRIPTION
Hi
I have been testing DDetours update proposed by vintagedave and noticed that there is no checking if hook was installed/removed successfully, so I added some checking. And this uncovered bug in DDetours that prevented hooks from uninstalling, this bug is fixed in this pull request. 
