### PR TITLE
Changed to not add "1" when renaming identifier

### DIFF
--- a/Source/SrcEditorEnhance/CnSrcEditorKey.pas
+++ b/Source/SrcEditorEnhance/CnSrcEditorKey.pas
@@ -1135,7 +1135,7 @@ begin
     begin
       try
         lblReplacePromt.Caption := Format(SCnRenameVarHintFmt, [Cur]);
-        edtRename.Text := Cur + '1';
+        edtRename.Text := Cur;
 //        case Rit of
 //          ritCurrentProc: rbCurrentProc.Checked := True;
 //          ritInnerProc: rbCurrentInnerProc.Checked := True;


### PR DESCRIPTION
I love rename identifier feature of cnpack, but I can't remember even single time when "1" (added each time) was actually needed. Most of the time I just have to delete it. For me and I guess for most of the users the best is to start from unchanged identifier name. 
