### PR TITLE
Updated UsesCleaner wizard to allow cleaning indirectly used units

### DIFF
--- a/Source/SimpleWizards/CnUsesCleanResultFrm.pas
+++ b/Source/SimpleWizards/CnUsesCleanResultFrm.pas
@@ -184,7 +184,7 @@ begin
         with TCnEmptyUsesInfo(ProjectInfo.Units[j]) do
         begin
           UnitNode := chktvResult.Items.AddChildObject(ProjNode,
-            _CnExtractFileName(Buffer.FileName), ProjectInfo.Units[j]);
+            _CnExtractFileName(SourceFileName), ProjectInfo.Units[j]);
           UnitNode.ImageIndex := IdxUnit;
           UnitNode.SelectedIndex := IdxUnit;
 
@@ -319,7 +319,7 @@ begin
     else if Obj is TCnUsesItem then
       Clipboard.AsText := TCnUsesItem(Obj).Name
     else if Obj is TCnEmptyUsesInfo then
-      Clipboard.AsText := _CnExtractFileName(TCnEmptyUsesInfo(Obj).Buffer.FileName)
+      Clipboard.AsText := _CnExtractFileName(TCnEmptyUsesInfo(Obj).SourceFileName)
     else
       Clipboard.AsText := FSelection.Text;
   end;

--- a/Source/SimpleWizards/CnUsesCleaner.dfm
+++ b/Source/SimpleWizards/CnUsesCleaner.dfm
@@ -3,7 +3,7 @@ inherited CnUsesCleanerForm: TCnUsesCleanerForm
   Top = 163
   BorderStyle = bsDialog
   Caption = 'Uses Units Cleaner'
-  ClientHeight = 365
+  ClientHeight = 384
   ClientWidth = 392
   PixelsPerInch = 96
   TextHeight = 13
@@ -11,7 +11,7 @@ inherited CnUsesCleanerForm: TCnUsesCleanerForm
     Left = 8
     Top = 8
     Width = 377
-    Height = 97
+    Height = 120
     Caption = '&Select Content to Process'
     TabOrder = 0
     object rbCurrUnit: TRadioButton
@@ -51,10 +51,18 @@ inherited CnUsesCleanerForm: TCnUsesCleanerForm
       TabOrder = 1
       TabStop = True
     end
+    object chkProcessDependencies: TCheckBox
+      Left = 8
+      Top = 96
+      Width = 361
+      Height = 17
+      Caption = 'Include indirecty used units'
+      TabOrder = 4
+    end
   end
   object btnOK: TButton
     Left = 150
-    Top = 336
+    Top = 356
     Width = 75
     Height = 21
     Caption = '&Process'
@@ -64,7 +72,7 @@ inherited CnUsesCleanerForm: TCnUsesCleanerForm
   end
   object btnCancel: TButton
     Left = 230
-    Top = 336
+    Top = 356
     Width = 75
     Height = 21
     Cancel = True
@@ -74,7 +82,7 @@ inherited CnUsesCleanerForm: TCnUsesCleanerForm
   end
   object btnHelp: TButton
     Left = 310
-    Top = 336
+    Top = 356
     Width = 75
     Height = 21
     Caption = '&Help'
@@ -83,7 +91,7 @@ inherited CnUsesCleanerForm: TCnUsesCleanerForm
   end
   object grpSettings: TGroupBox
     Left = 8
-    Top = 112
+    Top = 132
     Width = 377
     Height = 217
     Caption = 'Clean &Settings'

--- a/Source/Utils/CnDCU32.pas
+++ b/Source/Utils/CnDCU32.pas
@@ -95,22 +95,25 @@ type
 
   TCnEmptyUsesInfo = class
   private
-    FBuffer: IOTAEditBuffer;
+    FSourceFileName: string;
     FProject: IOTAProject;
     FDcuName: string;
     FIntfItems: TObjectList;
     FImplItems: TObjectList;
+
     function GetImplCount: Integer;
     function GetImplItem(Index: Integer): TCnUsesItem;
     function GetIntfCount: Integer;
     function GetIntfItem(Index: Integer): TCnUsesItem;
   public
-    constructor Create(const ADcuName: string; ABuffer: IOTAEditBuffer; AProject:
-      IOTAProject);
+    constructor Create(const ADcuName, ASourceFileName: string;
+      AProject: IOTAProject);
     destructor Destroy; override;
+
     function Process: Boolean;
+
     property DcuName: string read FDcuName;
-    property Buffer: IOTAEditBuffer read FBuffer;
+    property SourceFileName: string read FSourceFileName;
     property Project: IOTAProject read FProject;
     property IntfCount: Integer read GetIntfCount;
     property IntfItems[Index: Integer]: TCnUsesItem read GetIntfItem;
@@ -236,14 +239,14 @@ end;
 
 { TCnEmptyUsesInfo }
 
-constructor TCnEmptyUsesInfo.Create(const ADcuName: string; ABuffer: 
-  IOTAEditBuffer; AProject: IOTAProject);
+constructor TCnEmptyUsesInfo.Create(const ADcuName, ASourceFileName: string;
+  AProject: IOTAProject);
 begin
   inherited Create;
   FIntfItems := TObjectList.Create;
   FImplItems := TObjectList.Create;
   FDcuName := ADcuName;
-  FBuffer := ABuffer;
+  FSourceFileName := ASourceFileName;
   FProject := AProject;
 end;
 
@@ -271,7 +274,7 @@ begin
       try
         Stream := TMemoryStream.Create;
         try
-          EditFilerSaveFileToStream(Buffer.FileName, Stream);
+          EditFilerSaveFileToStream(FSourceFileName, Stream);
           // CnOtaSaveEditorToStream(Buffer, Stream);
           ParseUnitUses(PAnsiChar(Stream.Memory), UsesList);
         finally

--- a/Source/Utils/CnWizIdeUtils.pas
+++ b/Source/Utils/CnWizIdeUtils.pas
@@ -1367,7 +1367,7 @@ function GetFileNameFromModuleName(AName: string; AProject: IOTAProject = nil): 
 var
   Paths: TStringList;
   i: Integer;
-  Ext: string;
+  Ext, ProjectPath: string;
 begin
   if AProject = nil then
     AProject := CnOtaGetCurrentProject;
@@ -1386,18 +1386,22 @@ begin
         Result := AProject.GetModule(i).FileName;
         Exit;
       end;
+
+    ProjectPath := MakePath(_CnExtractFilePath(AProject.FileName));
+    if FileExists(ProjectPath + AName) then
+    begin
+      Result := ProjectPath + AName;
+      Exit;
+    end;
   end;
-  
+
   Paths := TStringList.Create;
   try
-    // 在工程搜索路径里查找
-    AddProjectPath(AProject, Paths, 'SrcDir');
-    for i := 0 to Paths.Count - 1 do
-      if FileExists(MakePath(Paths[i]) + AName) then
-      begin
-        Result := MakePath(Paths[i]) + AName;
-        Exit;
-      end;
+    if Assigned(AProject) then
+    begin
+      // 在工程搜索路径里查找
+      AddProjectPath(AProject, Paths, 'SrcDir');
+    end;
 
     // 在系统搜索路径里查找
     GetLibraryPath(Paths, False);


### PR DESCRIPTION
Current implementation of uses cleaner allows cleaning only units that are referenced in project. But most bigger project I have been working tend to not list all used units in project file, but instead set search path and use units from other units without referencing them in project. 
This update will allow cleaning all units used in project including those not listed directly in project.

I have added check box to turn on/off this feature.
There is also problem with locating unit source file when file is in project directory and not in search path, this is fixed GetFileNameFromModuleName function.