### PR TITLE
[Editor Enhancements] Enable Cursor Before EOL Feature

### DIFF
--- a/Source/SrcEditorEnhance/CnSrcEditorEnhance.pas
+++ b/Source/SrcEditorEnhance/CnSrcEditorEnhance.pas
@@ -628,12 +628,7 @@ begin
     chkAutoBracket.Checked := FEditorKey.AutoBracket;
     chkShiftEnter.Checked := FEditorKey.ShiftEnter;
     chkHomeExtend.Checked := FEditorKey.HomeExt;
-{$IFDEF DELPHI104_SYDNEY_UP}  // 10.4 无法支持光标行尾
-    chkCursorBeforeEOL.Checked := False;
-    chkCursorBeforeEOL.Enabled := False;
-{$ELSE}
     chkCursorBeforeEOL.Checked := FEditorKey.CursorBeforeEOL;
-{$ENDIF}
     chkLeftWrapLine.Checked := FEditorKey.LeftLineWrap;
     chkRightWrapLine.Checked := FEditorKey.RightLineWrap;
     chkSearchAgain.Checked := FEditorKey.F3Search;


### PR DESCRIPTION
As far as I can tell, feature was originally disabled because there was a second MouseUp event that didn't trigger EditorChange event in Sydney version of Delphi.
Adding the same EoL check to the MouseUp event gets around this.
I've been using this change locally for a couple of years without issue so far, so I believe it's safe.