### PR TITLE
Update TopRoller.dat

### DIFF
--- a/Bin/Data/TopRoller.dat
+++ b/Bin/Data/TopRoller.dat
@@ -1,2 +1,3 @@
 1|TAppBuilder|IDE Main Window
 1|TEditWindow|Source Editor
+1|TSplashFrm|IDE Splash Form


### PR DESCRIPTION
Fix the blank in SplashForm when CnWinTopRoller is active.

By default, CnWinTopRoller is active in TSplashFrm, it will generate some components and affect the SplashForm's backgound.

This issue was introduced in commit [fd1e449](https://github.com/cnpack/cnwizards/commit/fd1e4496dd4e29f5f8b45e1e8db6f644c0e25fe4)