### PR TITLE
* [DFMParser] Fix a Parse Float Error under Non-Dot Decimal Separator…

### DIFF
--- a/Source/Utils/CnWizDfmParser.pas
+++ b/Source/Utils/CnWizDfmParser.pas
@@ -830,10 +830,11 @@ var
 
 begin
   try
-    Parser := TParser.Create(Stream);
+    Parser := nil;
     SaveSeparator := {$IFDEF DELPHIXE3_UP}FormatSettings.{$ENDIF}DecimalSeparator;
-    {$IFDEF DELPHIXE3_UP}FormatSettings.{$ENDIF}DecimalSeparator := '.';
     try
+      {$IFDEF DELPHIXE3_UP}FormatSettings.{$ENDIF}DecimalSeparator := '.';
+      Parser := TParser.Create(Stream);
       PropCount := 0;
       ParseObject;
       Result := True;
@@ -1077,11 +1078,12 @@ var
   Parser: TParser;
   StartLeaf: TCnDfmLeaf;
 begin
-  Parser := TParser.Create(Stream);
   try
+    Parser := nil;
     SaveSeparator := {$IFDEF DELPHIXE3_UP}FormatSettings.{$ENDIF}DecimalSeparator;
-    {$IFDEF DELPHIXE3_UP}FormatSettings.{$ENDIF}DecimalSeparator := '.';
     try
+      {$IFDEF DELPHIXE3_UP}FormatSettings.{$ENDIF}DecimalSeparator := '.';
+      Parser := TParser.Create(Stream);
       StartLeaf := Tree.AddChild(Tree.Root) as TCnDfmLeaf;
       ParseTextObjectToLeaf(Parser, Tree, StartLeaf as TCnDfmLeaf);
       Result := True;


### PR DESCRIPTION
The FormatSettings configuration was moved before the TParser.Create call, as the FFormatSettings class member is initialized within it. Changing the FormatSettings after calling the constructor no longer affects the parser.